### PR TITLE
Update content

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -21,7 +21,7 @@ title: Index Page Example
           <p class="hero__description">
             Install GovWifi so your users can stay connected in any building.
           </p>
-          <a href="https://www.gov.uk/guidance/set-up-govwifi-on-your-infrastructure" role="button" class="hero-button">
+          <a href="https://govwifi-product-page.cloudapps.digital" role="button" class="hero-button">
             Get GovWifi for your organisation
           </a>
       </div>
@@ -36,8 +36,7 @@ title: Index Page Example
       <section class="content-section">
         <h2>No more wasted time finding passwords</h2>
         <p class="content-section__body">
-          Users only need to sign up once. <br>
-          After that they’ll automatically be connected in any building that uses Govwifi.
+          Users only need to sign up once to be automatically connected in any building that uses Govwifi.
         </p>
       </section>
     </div>
@@ -50,7 +49,7 @@ title: Index Page Example
       <section class="content-section content-section--with-top-border">
         <h2>Keep your existing infrastructure</h2>
         <p class="content-section__body">
-         You won't have to change your infrastructure or current Wifi provider.<br>
+         You won't have to change your infrastructure or current Wifi provider.
          GovWifi just makes all participating wifi networks appear as one to users.
         </p>
         </section>
@@ -58,22 +57,22 @@ title: Index Page Example
 
         <section class="content-section content-section--with-top-border">
         <h2>Designed to meet government security standards</h2>
-          <ul>
           <p>
             GovWifi is tested to keep users safe with features like:</p>
+          <ul>
           <li>protective monitoring to record activity, and raise alerts</li>
           <li>Encryption at rest</li>
           <li>Regular penetration testing</li>
         </ul>
-      </section>
+        </p>
+       </section>
 
-      
       <section class="content-section content-section--with-top-border">
         <h2>Supported by the team that builds it</h2>
           <p>
           GovWifi is built and managed by a full-time team of
-            developers, designers and product managers at GDS. </p>
-          <p>The team provides 24/7 support during office hours. </p>
+          developers, designers and product managers at GDS. </p>
+          <p>The team can provide support to your organisation during office hours. </p>
       </section>
 
 


### PR DESCRIPTION
Made content under 'no more wasted time finding passwords' shorter and more fluid.

Removed reference to 24/7 support as this was lifted from another service product page. 

Added link straight to the product page from the main 'call to action' at the top of the page.