### PR TITLE
End user "connect to GovWifi" page

### DIFF
--- a/source/connect.html.erb
+++ b/source/connect.html.erb
@@ -10,6 +10,64 @@ title: Help with Connecting to GovWifi
 
     <div class="column-two-thirds">
       <h1 class="heading-large">How to connect to GovWifi</h1>
+
+      <p class="grey-text-box">
+        By connecting to GovWifi, you accept the <%= link_to "terms and conditions", "https://www.gov.uk/government/publications/terms-and-conditions-for-connecting-to-govwifi/terms-and-conditions-for-connecting-to-govwifi"%> ,
+        and our <%= link_to "privacy notice", "https://www.gov.uk/government/publications/govwifi-privacy-notice" %>.
+      </p>
+
+      <p>
+        GovWifi is a secure wifi service, developed by Government Digital Service
+        (GDS). It’s currently in public beta, which means we’re still testing and
+        improving it.
+      </p>
+
+      <h2>Get your username and password for GovWifi</h2>
+      <p>
+        If you’re using GovWifi for the first time, you need to sign up to get your
+        unique username and password. <strong>You only need to do this once.</strong>
+      </p>
+
+      <p>
+        You can use the same username and password on all the devices you connect
+        to GovWifi. You can connect work devices and personal devices to GovWifi.
+        Once you’re set up, you can use GovWifi in any government building that offers it.
+      </p>
+
+      <p>
+        <strong>If you have a government email address</strong>
+      </p>
+      <p>
+        To sign up for yourself, send a blank email from your government email
+        address to <%= mail_to "signup@wifi.service.gov.uk" %>. You’ll receive
+        your username and password in reply.
+      </p>
+
+      <p>
+        To sign up one or more guests, send <strong>only</strong> their mobile
+        number <strong>or</strong> email address to <%= mail_to "sponsor@wifi.service.gov.uk" %>.
+        You’ll receive an email to confirm that a username and password has been
+        sent to each of your guests.
+      </p>
+
+      <p>
+        You can invite more than one guest - add as many mobile numbers or email
+        addresses as you want, on separate lines. The subject line is ignored, so
+        you can leave it blank.
+      </p>
+
+      <p>
+        Guests can be from outside government.
+      </p>
+
+      <p>
+        <strong>If you don’t have a government email address</strong>
+      </p>
+      <p>
+        Look for posters with instructions on how to sign up by text message or
+        ask the person you’re visiting to send an email to
+        <%= mail_to "sponsor@wifi.service.gov.uk" %> to give you access.
+      </p>
     </div>
   </div>
 </div>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -27,6 +27,7 @@
 
 @import "util/printable";
 @import "util/flexbox";
+@import "util/typography";
 
 @import "modules/breadcrumbs";
 @import "modules/content-section";

--- a/source/stylesheets/util/_typography.scss
+++ b/source/stylesheets/util/_typography.scss
@@ -1,0 +1,4 @@
+.grey-text-box {
+  padding: 32px;
+  background-color: $grey-3;
+}


### PR DESCRIPTION
Replaces https://www.gov.uk/government/collections/connect-to-govwifi

<img width="1038" alt="screen shot 2018-09-04 at 14 05 03" src="https://user-images.githubusercontent.com/2160769/45033139-9003bd00-b04b-11e8-9376-0686274b70af.png">
