### PR TITLE
Change sign up link, add tech docs link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -13,9 +13,13 @@ title: Index Page Example
           <p class="hero__description">
             Install GovWifi so your users can stay connected in any building.
           </p>
-          <a href="https://www.gov.uk/guidance/set-up-govwifi-on-your-infrastructure" role="button" class="hero-button">
+          <a href="https://admin-platform.wifi.service.gov.uk/users/sign_up" role="button" class="hero-button">
             Get GovWifi for your organisation
           </a>
+          <p class="hero__user-text">
+            Check if you're ready for GovWifi in our <%= link_to "technical documentation", 'https://govwifi-tech-docs.cloudapps.digital/requirements.html#requirements' %>.
+          </p>
+
           <p class="hero__user-text">
             Connecting to GovWifi as a user? See <%= link_to "instructions on how to connect", '/connect.html' %>.
           </p>


### PR DESCRIPTION
Sorts out these links on the home page:

![image](https://user-images.githubusercontent.com/429326/45085675-293cdd00-b0f9-11e8-94b7-db621e2380ac.png)

The links (from top) link to the sign up page, the tech docs' "requirements", and the end user guidance respectively.

This is all hard coded for the moment.