### PR TITLE
Add development command `live-serve` to restore live reload functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,9 @@ stop:
 	docker-compose kill
 	docker-compose rm -f
 
+live-serve:
+	bundle install --path vendor/bundle
+	npm install
+	bundle exec middleman server
+
 .PHONY: build deploy serve stop


### PR DESCRIPTION
Developers and content designers are likely to still find this useful.
Docker is fundamentally unable to support this functionality.

https://stackoverflow.com/a/37089784/3967444