### PR TITLE
Add get started page 

### DIFF
--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -1,1 +1,65 @@
-<h1> Get started </h1>
+---
+title: Get started - GovWifi
+---
+
+  <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
+      <ol itemscope itemtype="http://schema.org/BreadcrumbList">
+          <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+              <a href="/" itemprop="item"><span itemprop="name">GovWifi</span></a>
+          </li>
+          <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+              <a href="#main" itemprop="item"><span itemprop="name">Get started</span></a>
+          </li>
+      </ol>
+  </nav>
+
+<div class="container">
+  <div class="grid-row">
+      <div class="column-two-thirds column-minimum">
+        <h1 class="heading-large" style="padding-bottom: 15px" >Get started</h1>
+
+      <ol class="task-list">
+            <h2 class="task-list-section ">
+              <span class="govuk-list govuk-list--number">1.</span> Check GovWifi is right for you
+            </h2>
+            <div class="task-list-items" style="padding-bottom: 15px">
+              <p> <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">Read the documentation</a> and make sure you meet all the technical requirements.</p>
+              <p>You should also read and understand the:</p>
+              <ul class="list list-bullet">
+                <li> <a href="https://www.gov.uk/government/publications/terms-and-conditions-for-connecting-to-govwifi/terms-and-conditions-for-connecting-to-govwifi">terms and conditions</a> for any wifi users</li>
+                <li> <a href="https://www.gov.uk/government/publications/govwifi-privacy-notice">privacy notice</a></li>
+              </ul>
+            </div>
+
+
+          <h2 class="task-list-section">
+              <span class="govuk-list govuk-list--number">2.</span> Create an admin account
+          </h2>
+          <div class="task-list-items" style="padding-bottom: 15px">
+            <p>Create an admin account so you can:</p>
+              <ul class="list list-bullet">
+                <li> add new IP addresses </li>
+                <li> add new team members </li>
+                <li> find the connection details for GovWifi radius servers </li>
+              </ul>
+          </div>
+
+          <h2 class="task-list-section">
+              <span class="task-list-section-number">3.</span> Sign a memorandum of understanding
+          </h2>
+          <div class="task-list-items" style="padding-bottom: 15px">
+            <p>Someone in your organisation will need to sign the Memorandum of Understanding (MoU) before joining GovWifi. <p>
+            <p>Whoever signs the MoU must have permission to sign off and procure services in your organisations.</p>
+            <p>Contact us at <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a> for a copy of this document. </p>
+          </div>
+
+          <h2 class="task-list-section">
+              <span class="govuk-list govuk-list--number">4.</span> Configure your infrastructure
+          </h2>
+          <div class="task-list-items">
+            <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>
+          </div>
+        </ol>
+      </div>
+    </div>
+  </div>

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -1,0 +1,1 @@
+<h1> Get started </h1>

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -20,7 +20,7 @@ title: Get started - GovWifi
           <span class="govuk-list govuk-list--number">1.</span>
           Check GovWifi is right for you
         </h2>
-        <div class="task-list-items" style="padding-bottom: 15px">
+        <div class="task-list-items govuk-!-padding-bottom-3">
           <p> <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">Read the documentation</a> and make sure you meet all the technical requirements.</p>
           <p>You should also read and understand the:</p>
           <ul class="list list-bullet">
@@ -32,7 +32,7 @@ title: Get started - GovWifi
           <span class="govuk-list govuk-list--number">2.</span>
           Create an admin account
         </h2>
-        <div class="task-list-items" style="padding-bottom: 15px">
+        <div class="task-list-items govuk-!-padding-bottom-3">
           <p>Create an admin account so you can:</p>
           <ul class="list list-bullet">
             <li> add new IP addresses </li>
@@ -44,7 +44,7 @@ title: Get started - GovWifi
           <span class="task-list-section-number">3.</span>
           Sign a memorandum of understanding
         </h2>
-        <div class="task-list-items" style="padding-bottom: 15px">
+        <div class="task-list-items govuk-!-padding-bottom-3">
           <p>Someone in your organisation will need to sign the Memorandum of Understanding (MoU) before joining GovWifi.
           <p>
           <p>Whoever signs the MoU must have permission to sign off and procure services in your organisations.</p>
@@ -54,7 +54,7 @@ title: Get started - GovWifi
           <span class="govuk-list govuk-list--number">4.</span>
           Configure your infrastructure
         </h2>
-        <div class="task-list-items">
+        <div class="task-list-items govuk-!-padding-bottom-3">
           <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>
         </div>
       </ol>

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -17,7 +17,8 @@ title: Get started - GovWifi
       <h1 class="heading-large" style="padding-bottom: 15px" >Get started</h1>
       <ol class="task-list">
         <h2 class="task-list-section ">
-          <span class="govuk-list govuk-list--number">1.</span> Check GovWifi is right for you
+          <span class="govuk-list govuk-list--number">1.</span>
+          Check GovWifi is right for you
         </h2>
         <div class="task-list-items" style="padding-bottom: 15px">
           <p> <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">Read the documentation</a> and make sure you meet all the technical requirements.</p>
@@ -28,7 +29,8 @@ title: Get started - GovWifi
           </ul>
         </div>
         <h2 class="task-list-section">
-          <span class="govuk-list govuk-list--number">2.</span> Create an admin account
+          <span class="govuk-list govuk-list--number">2.</span>
+          Create an admin account
         </h2>
         <div class="task-list-items" style="padding-bottom: 15px">
           <p>Create an admin account so you can:</p>
@@ -39,7 +41,8 @@ title: Get started - GovWifi
           </ul>
         </div>
         <h2 class="task-list-section">
-          <span class="task-list-section-number">3.</span> Sign a memorandum of understanding
+          <span class="task-list-section-number">3.</span>
+          Sign a memorandum of understanding
         </h2>
         <div class="task-list-items" style="padding-bottom: 15px">
           <p>Someone in your organisation will need to sign the Memorandum of Understanding (MoU) before joining GovWifi.
@@ -48,7 +51,8 @@ title: Get started - GovWifi
           <p>Contact us at <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a> for a copy of this document. </p>
         </div>
         <h2 class="task-list-section">
-          <span class="govuk-list govuk-list--number">4.</span> Configure your infrastructure
+          <span class="govuk-list govuk-list--number">4.</span>
+          Configure your infrastructure
         </h2>
         <div class="task-list-items">
           <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>

--- a/source/getstarted.html.erb
+++ b/source/getstarted.html.erb
@@ -1,65 +1,59 @@
 ---
 title: Get started - GovWifi
 ---
-
-  <nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
-      <ol itemscope itemtype="http://schema.org/BreadcrumbList">
-          <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="/" itemprop="item"><span itemprop="name">GovWifi</span></a>
-          </li>
-          <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              <a href="#main" itemprop="item"><span itemprop="name">Get started</span></a>
-          </li>
-      </ol>
-  </nav>
-
+<nav class="breadcrumbs" aria-label="Breadcrumbs" data-click-events data-click-category="Header" data-click-action="Breadcrumb clicked">
+  <ol itemscope itemtype="http://schema.org/BreadcrumbList">
+    <li class="breadcrumbs__item breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="/" itemprop="item"><span itemprop="name">GovWifi</span></a>
+    </li>
+    <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="#main" itemprop="item"><span itemprop="name">Get started</span></a>
+    </li>
+  </ol>
+</nav>
 <div class="container">
   <div class="grid-row">
-      <div class="column-two-thirds column-minimum">
-        <h1 class="heading-large" style="padding-bottom: 15px" >Get started</h1>
-
+    <div class="column-two-thirds column-minimum">
+      <h1 class="heading-large" style="padding-bottom: 15px" >Get started</h1>
       <ol class="task-list">
-            <h2 class="task-list-section ">
-              <span class="govuk-list govuk-list--number">1.</span> Check GovWifi is right for you
-            </h2>
-            <div class="task-list-items" style="padding-bottom: 15px">
-              <p> <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">Read the documentation</a> and make sure you meet all the technical requirements.</p>
-              <p>You should also read and understand the:</p>
-              <ul class="list list-bullet">
-                <li> <a href="https://www.gov.uk/government/publications/terms-and-conditions-for-connecting-to-govwifi/terms-and-conditions-for-connecting-to-govwifi">terms and conditions</a> for any wifi users</li>
-                <li> <a href="https://www.gov.uk/government/publications/govwifi-privacy-notice">privacy notice</a></li>
-              </ul>
-            </div>
-
-
-          <h2 class="task-list-section">
-              <span class="govuk-list govuk-list--number">2.</span> Create an admin account
-          </h2>
-          <div class="task-list-items" style="padding-bottom: 15px">
-            <p>Create an admin account so you can:</p>
-              <ul class="list list-bullet">
-                <li> add new IP addresses </li>
-                <li> add new team members </li>
-                <li> find the connection details for GovWifi radius servers </li>
-              </ul>
-          </div>
-
-          <h2 class="task-list-section">
-              <span class="task-list-section-number">3.</span> Sign a memorandum of understanding
-          </h2>
-          <div class="task-list-items" style="padding-bottom: 15px">
-            <p>Someone in your organisation will need to sign the Memorandum of Understanding (MoU) before joining GovWifi. <p>
-            <p>Whoever signs the MoU must have permission to sign off and procure services in your organisations.</p>
-            <p>Contact us at <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a> for a copy of this document. </p>
-          </div>
-
-          <h2 class="task-list-section">
-              <span class="govuk-list govuk-list--number">4.</span> Configure your infrastructure
-          </h2>
-          <div class="task-list-items">
-            <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>
-          </div>
-        </ol>
-      </div>
+        <h2 class="task-list-section ">
+          <span class="govuk-list govuk-list--number">1.</span> Check GovWifi is right for you
+        </h2>
+        <div class="task-list-items" style="padding-bottom: 15px">
+          <p> <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">Read the documentation</a> and make sure you meet all the technical requirements.</p>
+          <p>You should also read and understand the:</p>
+          <ul class="list list-bullet">
+            <li> <a href="https://www.gov.uk/government/publications/terms-and-conditions-for-connecting-to-govwifi/terms-and-conditions-for-connecting-to-govwifi">terms and conditions</a> for any wifi users</li>
+            <li> <a href="https://www.gov.uk/government/publications/govwifi-privacy-notice">privacy notice</a></li>
+          </ul>
+        </div>
+        <h2 class="task-list-section">
+          <span class="govuk-list govuk-list--number">2.</span> Create an admin account
+        </h2>
+        <div class="task-list-items" style="padding-bottom: 15px">
+          <p>Create an admin account so you can:</p>
+          <ul class="list list-bullet">
+            <li> add new IP addresses </li>
+            <li> add new team members </li>
+            <li> find the connection details for GovWifi radius servers </li>
+          </ul>
+        </div>
+        <h2 class="task-list-section">
+          <span class="task-list-section-number">3.</span> Sign a memorandum of understanding
+        </h2>
+        <div class="task-list-items" style="padding-bottom: 15px">
+          <p>Someone in your organisation will need to sign the Memorandum of Understanding (MoU) before joining GovWifi.
+          <p>
+          <p>Whoever signs the MoU must have permission to sign off and procure services in your organisations.</p>
+          <p>Contact us at <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a> for a copy of this document. </p>
+        </div>
+        <h2 class="task-list-section">
+          <span class="govuk-list govuk-list--number">4.</span> Configure your infrastructure
+        </h2>
+        <div class="task-list-items">
+          <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>
+        </div>
+      </ol>
     </div>
   </div>
+</div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -12,7 +12,7 @@ title: Index Page Example
         <p class="hero__description">
           Install GovWifi so your users can stay connected in any building.
         </p>
-        <%= link_to "Get GovWifi for your organisation", "https://admin.wifi.service.gov.uk/users/sign_up", class: "hero-button" %>
+        <%= link_to "Get GovWifi for your organisation", "/getstarted.html", class: "hero-button" %>
         <p class="hero__user-text"> Check if you're ready for GovWifi in our <a href="https://docs.wifi.service.gov.uk/requirements.html#requirements">technical documentation</a>. </p>
         <p class="hero__user-text"> Connecting to GovWifi as a user? See <a href="/connect.html">instructions on how to connect</a></p>
       </div>


### PR DESCRIPTION
Add a get started page to the GovWifi product page site to allow users to not feel overwhelmed when signing up. By providing this get started page it gives the user information they may need in order to sign up to GovWifi.