### PR TITLE
Correct link to tech docs

### DIFF
--- a/source/get-started.html.erb
+++ b/source/get-started.html.erb
@@ -66,7 +66,7 @@ title: Get started
           Configure your infrastructure
         </h2>
         <div class="task-list-items">
-          <p>You’ll find help on how to do this within your account but you can also  <a href="https://docs.wifi.service.gov.uk/phase1.html#phase-1-create-a-new-wifi-installation">follow the phases in the documentation.</a></p>
+          <p>You’ll find help on how to do this within your account, but you can also <a href="https://docs.wifi.service.gov.uk/set_up">read our documentation.</a></p>
         </div>
       </ol>
     </div>


### PR DESCRIPTION
Tech docs doesn't have phases any more, and linking to phase 1 doesn't work.

Direct people to the "set up GovWifi" section instead.