### PR TITLE
Explicitly install npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 
-RUN apk --update add g++ musl-dev make nodejs
+RUN apk --update add g++ musl-dev make nodejs nodejs-npm
 RUN bundle install
 
 COPY . .


### PR DESCRIPTION
Our build started failing 2 days ago with
`/bin/sh: npm: not found`

Reading the Alpine documentation for installing npm suggests that you
have to install nodejs-npm.

Unsure how this ever worked but explicitly adding this package seems
like a reasonable thing to do.