### PR TITLE
Add support link to top navigation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -57,8 +57,9 @@
 
           <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
             <ul>
-              <li><%= link_to "Documentation", "https://docs.wifi.service.gov.uk" %></li>
-              <li><%= link_to "Admin", "https://admin.wifi.service.gov.uk/users/sign_in" %></li>
+              <li><%= link_to 'Documentation', 'https://docs.wifi.service.gov.uk' %></li>
+              <li><%= link_to 'Support', 'https://admin.wifi.service.gov.uk/help' %></li>
+              <li><%= link_to 'Admin', 'https://admin.wifi.service.gov.uk/users/sign_in' %></li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
This currently points to the admin support page.
This will be updated once we have a new support page for non signed in
users.