### PR TITLE
Make primary navigation consistent with other apps

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,6 @@
 @import "core";
+
+.header__navigation li {
+  min-width: 55px;
+  text-align: right;
+}


### PR DESCRIPTION
We sometimes have "Admin" as a menu item, and when you are on the admin,
it says "Sign in".  This uses up a different amount of space, so set a
min width to ensure the navigation doesn't mover around when you browse
between the apps.