### PR TITLE
Align main image and remove hero white space

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,5 +1,5 @@
 <div class="masthead">
-  <div class="hero hero--breaded">
+  <div class="hero">
     <div class="hero__content">
       <div class="hero__body">
         <h1 class="hero__title">Join GovWifi so your users stay connected across organisations</h1>
@@ -14,8 +14,8 @@
           Or, <%= link_to "log in to an existing admin account", 'https://admin.wifi.service.gov.uk/users/sign_in' %>.
         </p>
       </div>
-      <div class="hero__aside-image">
-        <img src="/images/Product-illustration-150-crop-2.png" alt="" role="presentation" width="100%">
+      <div class="hero__aside-image main-image">
+        <img src="/images/Product-illustration-150-crop-2.png" alt="govwifi-image" role="presentation" width="100%">
       </div>
     </div>
   </div>

--- a/source/stylesheets/modules/_images.scss
+++ b/source/stylesheets/modules/_images.scss
@@ -2,3 +2,7 @@
   max-width: 100%;
   height: auto;
 }
+
+.main-image {
+  margin-top: 30px;
+}


### PR DESCRIPTION
Before:
Ugly white space...
![screenshot 2018-12-04 at 16 48 17](https://user-images.githubusercontent.com/2160769/49458275-6b52e900-f7e4-11e8-842f-c91d54138034.png)
Bad alignment...
![screenshot 2018-12-04 at 16 48 10](https://user-images.githubusercontent.com/2160769/49458293-7574e780-f7e4-11e8-81c7-e5575038061b.png)

After:
![screenshot 2018-12-04 at 16 46 46](https://user-images.githubusercontent.com/2160769/49458306-7c9bf580-f7e4-11e8-8907-916caf08cb04.png)
![screenshot 2018-12-04 at 16 33 31](https://user-images.githubusercontent.com/2160769/49458313-7f96e600-f7e4-11e8-8672-738ffa9583cb.png)
