### PR TITLE
Add beta banner

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -61,6 +61,7 @@
             </span>
             <span class="header__title">
               GovWifi
+              <span class="phase-banner">Beta</span>
             </span>
           </a>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/429326/52570727-f5828380-2e0b-11e9-8c2f-f0c6eb343c59.png)

The spacing (between "GOV.UK", "GovWifi" and the badge) looks slightly off to me, but wanted to get this in front of some :eyes: to see if that's just me being pedantic. 
