### PR TITLE
Fix nav menu spacing

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -72,7 +72,7 @@
             <ul>
               <li><%= link_to 'Documentation', 'https://docs.wifi.service.gov.uk' %></li>
               <li><%= link_to 'Support', 'https://admin.wifi.service.gov.uk/help' %></li>
-              <li><%= link_to 'Sign in', 'https://admin.wifi.service.gov.uk/users/sign_in' %></li>
+              <li><%= link_to 'Admin', 'https://admin.wifi.service.gov.uk/users/sign_in' %></li>
             </ul>
           </nav>
         </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -72,7 +72,7 @@
             <ul>
               <li><%= link_to 'Documentation', 'https://docs.wifi.service.gov.uk' %></li>
               <li><%= link_to 'Support', 'https://admin.wifi.service.gov.uk/help' %></li>
-              <li><%= link_to 'Admin', 'https://admin.wifi.service.gov.uk/users/sign_in' %></li>
+              <li><%= link_to 'Sign in', 'https://admin.wifi.service.gov.uk/users/sign_in' %></li>
             </ul>
           </nav>
         </div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,6 +1,5 @@
 @import "core";
 
 .header__navigation li {
-  min-width: 55px;
   text-align: right;
 }


### PR DESCRIPTION
Now with perfectly spaced links - and back to the "admin" wording.

![image](https://user-images.githubusercontent.com/429326/52626443-1a7a0380-2eab-11e9-885a-df9f7d7f3ae6.png)

This, in part, reverts https://github.com/alphagov/govwifi-product-page/pull/31, but leaves https://github.com/alphagov/govwifi-product-page/pull/28 in place.