### PR TITLE
Remove Tag Manager Implementation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -16,14 +16,6 @@
       });
     </script>
 
-  <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-TNHHHPZ');</script>
-  <!-- End Google Tag Manager -->
-
     <meta charset="utf-8">
 
     <title><%= current_page.data.title && "#{current_page.data.title} – " %>GOV.UK GovWifi</title>
@@ -44,11 +36,7 @@
   </head>
 
   <body>
-  <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TNHHHPZ"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-  
+
     <a href="#main" class="skip-link">Skip to main content</a>
 
     <header class="header<% if current_page.url == '/' %> header--without-border<% end %>">


### PR DESCRIPTION
**WHAT:** 
This removes the current installation of Google Tag Manager in the product page. 

**WHY:**
This was done in preparation for the current installation of Google Analytics in the product page to be reconfigured.
