### PR TITLE
Improve hero text

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,16 +2,16 @@
   <div class="hero">
     <div class="hero__content">
       <div class="hero__body">
-        <h1 class="hero__title">Join GovWifi so your users stay connected across organisations</h1>
+        <h1 class="hero__title">Offer GovWifi in your building or organisation</h1>
         <div class="hero__inline-image">
           <img src="/images/Product-illustration.png" alt="" role="presentation" width="100%">
         </div>
         <p class="hero__description">
-          Make your public sector network accessible through a single user login.
+          Help users stay connected across organisations with GovWifi's single user login.
         </p>
         <%= link_to "See how to get started", "/get-started", class: "hero-button" %>
         <p class="hero__user-text">
-          Or, <%= link_to "sign in to an existing admin account", 'https://admin.wifi.service.gov.uk/users/sign_in' %>.
+          Or, <%= link_to "manage an existing GovWifi installation", 'https://admin.wifi.service.gov.uk/users/sign_in' %>.
         </p>
       </div>
       <div class="hero__aside-image main-image">


### PR DESCRIPTION
Improve hero text to make it more direct and more targeted to admin users. This will hopefully have the two fold effect of making it clearer to potential organisations as well as more obvious to end users that they are not in the right place:

![image](https://user-images.githubusercontent.com/2160769/55163482-c9c02080-5161-11e9-810c-eda151f61999.png)
