### PR TITLE
Add connect to govwifi page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,6 +499,11 @@
         }
       }
     },
+    "govuk-frontend": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.10.0.tgz",
+      "integrity": "sha512-Tfo76yz5ybFMX1heojeiWAyxUx0gABM2/hfMk1zu+9hWvApmfxeTaQOJkje4jeo1ybRo+FhgKFqqAzkBOOUnqg=="
+    },
     "govuk_frontend_toolkit": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "gaap-analytics": "^3.0.0",
     "govuk-elements-sass": "^3.1.3",
+    "govuk-frontend": "^2.10.0",
     "govuk_frontend_toolkit": "^8.1.0"
   },
   "devDependencies": {

--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -24,7 +24,7 @@ title: Connect to GovWifi
       <p>We will email your username and password in reply.</p>
       <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
       <div class="govuk-inset-text">
-        <a href="/connect-visitors-to-govwifi">Connect to GovWifi without a government or public sector email address</a>
+        <a href="/support/connect-visitors-to-govwifi">Connect to GovWifi without a government or public sector email address</a>
       </div>
     </div>
   </div>

--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -4,7 +4,28 @@ title: Connect to GovWifi
 
 <div class="container">
   <div class="grid-row">
-    <h1 class="heading-large">Connect staff to GovWifi</h1>
+    <div class="column-one-third">
+      <div>
+        <%= partial 'shared/support/sidebar' %>
+      </div>
+    </div>
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Connect to GovWifi</h1>
+      <p>If you have a government or public sector organisation email address, you need to sign up to get to get your unique username and password.</p>
+      <p>You can check if your government or public sector organisation email address is eligible for GovWifi.</p>
+      <div>
+        <p>You will need to use your government or public sector organisation email address to:</p>
+        <ul class="list list-bullet">
+          <li>send a blank email to signup@wifi.service.gov.uk</li>
+          <li>leave the subject line blank</li>
+          <li>read and accept the terms and conditions, and our privacy notice.</li>
+        </ul>
+      </div>
+      <p>We will email your username and password in reply.</p>
+      <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
+      <div class="govuk-inset-text">
+        <a href="/connect-visitors-to-govwifi">Connect to GovWifi without a government or public sector email address</a>
+      </div>
+    </div>
   </div>
 </div>
-

--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -24,7 +24,7 @@ title: Connect to GovWifi
       <p>We will email your username and password in reply.</p>
       <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
       <div class="govuk-inset-text">
-        <a href="/support/connect-visitors-to-govwifi">Connect to GovWifi without a government or public sector email address</a>
+        <%= link_to "Connect to GovWifi without a government or public sector email address", "/support/connect-visitors-to-govwifi" %>
       </div>
     </div>
   </div>

--- a/source/shared/support/_sidebar.html.erb
+++ b/source/shared/support/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <nav class="sub-navigation">
   <ul>
     <li>
-      <a href="#">Connect to GovWifi</a>
+      <a href="/connect-to-govwifi">Connect to GovWifi</a>
     </li>
   </ul>
 </nav>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -1,5 +1,7 @@
 @charset "utf-8";
 
+@import "govuk-frontend/components/inset-text/inset-text";
+
 @import "govuk_frontend_toolkit/stylesheets/colours";
 @import "govuk_frontend_toolkit/stylesheets/conditionals";
 @import "govuk_frontend_toolkit/stylesheets/css3";


### PR DESCRIPTION
**WHY:**
_Product Page Revamp!_

**IN THIS PR:**
- Add new connect to GovWifi Page:

![Screenshot 2019-04-24 at 14 34 55](https://user-images.githubusercontent.com/32823756/56663595-5ea13580-669e-11e9-8162-cdd6542895fb.png)

- Add govuk-frontend to `package.json`
- Import style into [`_core.scss`](source/stylesheets/_core.scss)