### PR TITLE
Add eligible and mail-to links

### DIFF
--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -12,11 +12,11 @@ title: Connect to GovWifi
     <div class="column-two-thirds">
       <h1 class="heading-large">Connect to GovWifi</h1>
       <p>If you have a government or public sector organisation email address, you need to sign up to get to get your unique username and password.</p>
-      <p>You can check if your government or public sector organisation email address is eligible for GovWifi.</p>
+      <p>You can check if your government or public sector organisation email address is <%= link_to "eligible", "/support/check-organisation-email-address" %> for GovWifi.</p>
       <div>
         <p>You will need to use your government or public sector organisation email address to:</p>
         <ul class="list list-bullet">
-          <li>send a blank email to signup@wifi.service.gov.uk</li>
+          <li>send a blank email to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %></li>
           <li>leave the subject line blank</li>
           <li>read and accept the terms and conditions, and our privacy notice.</li>
         </ul>


### PR DESCRIPTION
- Add link within the page to `/support/check-organisation-email-address`
- Add mail to link to `signup@wifi.service.gov.uk`

![Screenshot 2019-04-24 at 15 08 16](https://user-images.githubusercontent.com/32823756/56665961-f56ff100-66a2-11e9-8eaf-5a74c98d9a8c.png)
