### PR TITLE
Edit connect your device link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -23,7 +23,7 @@
     <div class="column-one-third">
       <h2>Access GovWifi</h2>
       <p>Sign up to connect your device to the GovWifi network across the public sector.</p>
-      <%= link_to "Connect your device", "https://www.wifi.service.gov.uk/connect-to-govwifi", class: "govuk-link" %>
+      <%= link_to "Connect your device", "/connect-to-govwifi", class: "govuk-link" %>
     </div>
 
     <div class="column-one-third">


### PR DESCRIPTION
- Edit link to `connect your device`.
Former link led to a blank page on `https://www.wifi.service.gov.uk`.