### PR TITLE
Add meta description to Connect to GovWifi page

### DIFF
--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect to GovWifi
+description: Use your government or public sector email address to connect to GovWifi.
 ---
 
 <div class="container">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,6 +10,7 @@
     <link rel="shortcut icon" href="<%= asset_path :images, 'favicon.ico' %>" type="image/x-icon" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="<%= current_page.data.description %>">
 
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
     <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->


### PR DESCRIPTION
IN THIS PR:
- Add meta tag to [layout.erb](source/layouts/layout.erb) file
- Add description to Connect to GovWifi page:

Inspecting the page shows:

![Screenshot 2019-04-24 at 16 08 19](https://user-images.githubusercontent.com/32823756/56670753-4b489700-66ab-11e9-8fe8-0962ab39929d.png)