### PR TITLE
Move stack to cflinux3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ serve: build
 	docker-compose run --service-ports app bundle exec middleman server
 
 deploy: build
-	docker-compose run app sh -c "cf login -u ${CF_USER} -p ${CF_PASS} -a https://api.cloud.service.gov.uk -s production && cf push govwifi-product-page"
+	docker-compose run app sh -c "cf login -u ${CF_USER} -p ${CF_PASS} -a https://api.cloud.service.gov.uk -s production && cf push govwifi-product-page -s cflinux3"
 	$(MAKE) stop
 
 stop:


### PR DESCRIPTION
cflinux2 is EOL.  Add the argument to migrate to cflinux3 in the
Makefile.  This can be reverted once applied.

Documentation on this here:
https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html