### PR TITLE
Add privacy notice page

### DIFF
--- a/source/privacy-notice.html.erb
+++ b/source/privacy-notice.html.erb
@@ -1,0 +1,192 @@
+---
+title: Privacy notice - GovWifi
+description: Find details about the GovWifi privacy policy and how we collect and process your data.
+---
+
+<div class="container">
+  <div class="grid-row">
+    <div class="column-one-third sticky">
+      <div>
+        <%= partial 'shared/privacy_notice_sidebar' %>
+      </div>
+    </div>
+    <div class="column-two-thirds">
+      <h1 class="heading-large">GovWifi privacy notice</h1>
+      <h2 class="heading-medium" id="who-we-are">Who we are</h2>
+      <p>
+        GovWifi is a secure wifi service, developed by GDS. It provides wifi access in government buildings.
+      </p>
+      <p>
+        GovWifi is currently in public beta, which means we’re still testing and improving it.
+      </p>
+      <p>
+        GovWifi is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.
+      </p>
+      <p>
+        The data controller for GDS is the Cabinet Office.
+        They determine how and why personal data is processed.
+        <%= link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053" %> for more information.
+      </p>
+      <h2 class="heading-medium" id="what-data-we-need">What data we need</h2>
+      <p>
+        In order that GovWifi can work effectively for you we will need the following data:
+        <ul class="list list-bullet">
+          <li>email address OR mobile telephone number</li>
+          <li>the number of authentication attempts you make</li>
+          <li>activation and login dates</li>
+        </ul>
+      </p>
+      <p>
+        We also identify the buildings in which you access GovWifi.
+      </p>
+      <p>
+        The legal reason we process this data is to let users in government, arm’s length bodies and public sector organisations stay connected to a secure wifi service while visiting other departments and moving between buildings.
+      </p>
+      <h2 class="heading-medium" id="why-we-need-it">Why we need it</h2>
+      <p>
+        We need to know when you last used GovWifi so we can delete your account if it has not been used for 12 months.
+      </p>
+      <p>
+        We need to know your email address or mobile phone number so that we can notify you about major changes to the service or changes to the terms and conditions.
+        For example, if the current inactive account deletion period of 12 months is reduced.
+      </p>
+      <p>
+        In accepting the terms and conditions of use you agree to the acceptable use policy of your host organisation.
+        That organisation may restrict access for lawful purposes.
+        We are obliged to be able to identify users who do not comply with these terms and conditions so access can be restricted/terminated.
+      </p>
+      <h2 class="heading-medium" id="what-we-do-with-it">What we do with it</h2>
+      <p>
+        GDS will share this information with any host organisation from which you access the service if they request it.
+      </p>
+      <p>
+        GDS may occasionally contact you by email or text message, using the information you’ve provided, to give you important information about the GovWifi service, including:
+        <ul class="list list-bullet">
+          <li>major changes to GovWifi, like restricting access to non-public sector workers</li>
+          <li>changes to these terms and conditions</li>
+          <li>requests for feedback to improve GovWifi</li>
+        </ul>
+      </p>
+      <p>
+        We will not:
+        <ul class="list list-bullet">
+          <li>sell or rent your data to third parties</li>
+          <li>share your data with third parties for marketing purposes</li>
+        </ul>
+      </p>
+      <p>
+        We will share your data if we are required to by law – for example, by court order, or to prevent fraud or other crime.
+      </p>
+      <h2 class="heading-medium" id="how-long-we-keep-your-data">How long we keep your data</h2>
+      <p>
+        We will only retain your personal data for as long as:
+        <ul class="list list-bullet">
+          <li>the law requires us to</li>
+          <li>we need to provide this service to you</li>
+        </ul>
+      </p>
+      <h2 class="heading-medium" id="childrens-privacy-protection">Children’s privacy protection</h2>
+      <p>
+        Our services are not designed for, or intentionally targeted at, children 13 years of age or younger.
+        It is not our policy to intentionally collect or maintain data about anyone under the age of 13.
+      </p>
+      <h2 class="heading-medium" id="where-it-might-go">Where it might go</h2>
+      <p>
+        We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s processed and when it’s stored.
+      </p>
+      <p>
+        GDS will not process your personal data, or transfer it, outside of the <%= link_to "European Economic Area (EEA)", "https://www.gov.uk/eu-eea" %>.
+      </p>
+      <h2 class="heading-medium " id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
+      <p>
+        We are committed to keeping your data secure.
+        We set up systems and processes to prevent unauthorised access or disclosure of the data we collect about you – for example, we protect your data using varying levels of encryption.
+        We also make sure that third parties we deal with have an obligation to keep all personal data they process on our behalf secure.
+      </p>
+      <h2 class="heading-medium" id="what-are-your-rights">What are your rights</h2>
+      <p>
+        You have the right to request:
+        <ul class="list list-bullet">
+          <li>information about how your personal data is processed</li>
+          <li>a copy of any personal data you have provided in an accessible format</li>
+          <li>that anything inaccurate in your personal data is corrected immediately</li>
+          <li>to raise an objection about how your personal data is processed</li>
+          <li>that your personal data is erased if there is no longer a justification for it</li>
+          <li>that the processing of your personal data is restricted in certain circumstances</li>
+        </ul>
+      </p>
+      <p>
+        If you have any of these requests, get in contact with our Data Protection Officer.
+        Contact details can be found below.
+      </p>
+      <h2 class="heading-medium" id="changes-to-this-notice">Changes to this notice</h2>
+      <p>
+        We may modify or amend this privacy notice at our discretion at any time.
+        When we make changes to this notice, we will amend the last modified date at the top of this page.
+        Any modification or amendment to this privacy notice will be applied to you and your data as of that revision date.
+        If these changes affect how your personal data is processed, GDS will take reasonable steps to make sure you know.
+      </p>
+      <h2 class="heading-medium" id="how-to-contact-us">How to contact us</h2>
+      <p>
+        The data controller for your personal data is the Cabinet Office.
+      </p>
+      <p>
+        Contact the Data Protection Officer if you either:
+        <ul class="list list-bullet">
+          <li>have any questions about anything in this document</li>
+          <li>think that your personal data has been misused or mishandled</li>
+        </ul>
+      </p>
+      <h3 class="heading-small">Data Protection Officer</h3>
+      <p>
+        Cabinet Office
+        <br/>
+        70 Whitehall
+        <br/>
+        London
+        <br/>
+        SW1A 2AS
+      </p>
+      <p>
+        Email
+        <br/>
+        <%= link_to "DPO@cabinetoffice.gov.uk", "mailto: DPO@cabinetoffice.gov.uk" %>
+      </p>
+      <p>
+        If you have a complaint, you can also contact the <%= link_to "Information Commissioner", "https://ico.org.uk" %>, who is an independent regulator set up to uphold information rights.
+      </p>
+      <h3 class="heading-small">Information Commissioner's Office</h3>
+      <p>
+        Wycliffe House
+        <br/>
+        Water Lane
+        <br/>
+        Wilmslow
+        <br/>
+        Cheshire
+        <br/>
+        SK9 5AF
+      </p>
+      <p>
+        Email
+        <br/>
+        <%= link_to "casework@ico.org.uk", "mailto: casework@ico.org.uk" %>
+      </p>
+      <p>
+        Contact form
+        <br/>
+        <%= link_to "https://ico.org.uk/global/contact-us/email/", "https://ico.org.uk/global/contact-us/email/" %>
+      </p>
+      <p>
+        Telephone
+        <br/>
+        0303 123 1113
+      </p>
+      <p>
+        Textphone
+        <br/>
+        01625 545860
+      </p>
+    </div>
+  </div>
+</div>

--- a/source/shared/_privacy_notice_sidebar.html.erb
+++ b/source/shared/_privacy_notice_sidebar.html.erb
@@ -1,0 +1,22 @@
+<% menu_items = [
+  { title: "Who we are", link: "#who-we-are" },
+  { title: "What data we need", link: "#what-data-we-need" },
+  { title: "Why we need it", link: "#why-we-need-it" },
+  { title: "What we do with it", link: "#what-we-do-with-it" },
+  { title: "How long we keep your data", link: "#how-long-we-keep-your-data" },
+  { title: "Children’s privacy protection", link: "#childrens-privacy-protection" },
+  { title: "Where it might go", link: "#where-it-might-go" },
+  { title: "What are your rights", link: "#what-are-your-rights" },
+  { title: "Changes to this notice", link: "#changes-to-this-notice" },
+  { title: "How to contact us", link: "#how-to-contact-us" }
+] %>
+
+<nav class="sub-navigation">
+  <ul>
+    <% menu_items.each do |menu_item| %>
+      <li class="sub-navigation__item <%= subnav_active(menu_item.fetch(:link)) %>">
+        <%= link_to menu_item.fetch(:title), menu_item.fetch(:link), class: "govuk-link" %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/source/shared/_privacy_notice_sidebar.html.erb
+++ b/source/shared/_privacy_notice_sidebar.html.erb
@@ -14,7 +14,7 @@
 <nav class="sub-navigation">
   <ul>
     <% menu_items.each do |menu_item| %>
-      <li class="sub-navigation__item <%= subnav_active(menu_item.fetch(:link)) %>">
+      <li class="sub-navigation__item">
         <%= link_to menu_item.fetch(:title), menu_item.fetch(:link), class: "govuk-link" %>
       </li>
     <% end %>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -44,6 +44,7 @@
 @import "modules/images";
 @import "modules/masthead";
 @import "modules/phase-banner";
+@import "modules/sticky";
 @import "modules/related-items";
 @import "modules/responsive-embed";
 @import "modules/skip-link";

--- a/source/stylesheets/modules/_sticky.scss
+++ b/source/stylesheets/modules/_sticky.scss
@@ -1,0 +1,13 @@
+// Sticky Element Component
+//
+// Example Usage:
+//
+// <span class="header__title">
+//   My Product <span class="sticky">Beta</span>
+// </span>
+
+.sticky {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+}


### PR DESCRIPTION
**IN THIS PR:**
- Add privacy notice page & [copied content](https://www.gov.uk/government/publications/govwifi-privacy-notice/govwifi-privacy-notice) from GOV.UK page.

![Screenshot 2019-04-25 at 15 31 04](https://user-images.githubusercontent.com/32823756/56744133-d2f7d980-676f-11e9-9ae4-fef81645066e.png)

------------------------------------------------------------------------------------------------------

- Add anchor links and side bar navigation for the page.

- Add sticky styling to column to mimic [GOV.UK Registers'](https://www.registers.service.gov.uk/privacy-notice) version of navigation on that page.
(This was requested.)

![Screenshot 2019-04-25 at 15 31 22](https://user-images.githubusercontent.com/32823756/56744145-d8edba80-676f-11e9-9032-a1f43c2e30c0.png)

_Notice that the sidebar sticks to the screen when it's position reaches the top, even though the rest of the page is mid scroll_ 

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**