### PR TITLE
Remove GAAP analytics init script

### DIFF
--- a/source/javascripts/start-modules.js
+++ b/source/javascripts/start-modules.js
@@ -3,5 +3,4 @@
 
 $(document).ready(function() {
   GOVUK.modules.start();
-  window.GAAP.analytics.init()
 });


### PR DESCRIPTION
This is unused and trying to initialise it throws an error.