### PR TITLE
Change connect-to-govwifi links

### DIFF
--- a/source/about-govwifi.html.erb
+++ b/source/about-govwifi.html.erb
@@ -19,7 +19,7 @@ description: GovWifi is an authentication service that makes all participating g
         Staff and visitors are able to connect to a single secure guest wifi service as they move across multiple government and public sector organisations.
       </p>
       <div class="govuk-inset-text">
-        <%= link_to "Learn more about how to connect your device to GovWifi", "/connect-to-govwifi" %>
+        <%= link_to "Learn more about how to connect your device to GovWifi", "/about-govwifi/connect-to-govwifi" %>
       </div>
     </div>
   </div>

--- a/source/about-govwifi/how-govwifi-works.html.erb
+++ b/source/about-govwifi/how-govwifi-works.html.erb
@@ -29,7 +29,7 @@ description: Learn more about how the GovWifi authenication service works.
       </p>
       <div class="govuk-inset-text">
         <p>
-          If you are trying to connect your device to GovWifi please follow these <%= link_to "sign up instructions.", "/connect-to-govwifi" %>
+          If you are trying to connect your device to GovWifi please follow these <%= link_to "sign up instructions.", "/about-govwifi/connect-to-govwifi" %>
         </p>
       </div>
       <h2>Offer GovWifi in your organisation</h2>

--- a/source/about-govwifi/organisations-using-govwifi.html.erb
+++ b/source/about-govwifi/organisations-using-govwifi.html.erb
@@ -15,7 +15,7 @@ description: Find all the public sector organisations where GovWifi is available
       <p>
         GovWifi is currently available in a wide range of government and public
         sector organisations. Learn more about how to
-        <%= link_to "connect your device to GovWifi", "/connect-to-govwifi" %>
+        <%= link_to "connect your device to GovWifi", "/about-govwifi/connect-to-govwifi" %>
       </p>
 
       <% organisations = data.organisations.sort %>

--- a/source/about-govwifi/who-govwifi-is-for.html.erb
+++ b/source/about-govwifi/who-govwifi-is-for.html.erb
@@ -36,7 +36,7 @@ description: Learn more about how GovWifi supports public sector staff and visit
         public sector locations.
       </p>
       <div class="govuk-inset-text">
-        <%= link_to "Learn more about how to connect your device to GovWifi", "/connect-to-govwifi" %>
+        <%= link_to "Learn more about how to connect your device to GovWifi", "/about-govwifi/connect-to-govwifi" %>
       </div>
     </div>
   </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -49,7 +49,7 @@
           <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
             <ul>
               <li><%= link_to 'About', '/about-govwifi' %></li>
-              <li><%= link_to 'Connect to GovWifi', '/connect-to-govwifi' %></li>
+              <li><%= link_to 'Connect to GovWifi', '/about-govwifi/connect-to-govwifi' %></li>
               <li><%= link_to 'Offer GovWifi', 'https://docs.wifi.service.gov.uk' %></li>
               <li><%= link_to 'Support', '/support' %></li>
             </ul>

--- a/source/support/check-organisation-email-address.html.erb
+++ b/source/support/check-organisation-email-address.html.erb
@@ -9,7 +9,7 @@ description: Check your government or public sector email address to sign up to 
     </div>
     <div class="column-two-thirds">
       <h1>Check your organisation email address</h1>
-      <p>You can <%= link_to "signup to GovWifi", "/connect-to-govwifi", class: "govuk-link" %>
+      <p>You can <%= link_to "signup to GovWifi", "/about-govwifi/connect-to-govwifi", class: "govuk-link" %>
         using your government or public sector email address
       </p>
       <p>If you don't have a government or public sector email address, you can

--- a/source/support/connect-to-govwifi-using-a-blackberry.html.erb
+++ b/source/support/connect-to-govwifi-using-a-blackberry.html.erb
@@ -13,7 +13,7 @@ title: Connect a Blackberry - GovWifi
       <p>If your device was made before October 2016, you're probably running the BlackBerry operating system (OS). Follow these instructions to connect to GovWifi.</p>
 
       <h2 class="heading-medium">Instructions</h2>
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
       <p>Step 1 - Open your wifi settings. A list of wifi networks appears.</p>
       <p>Step 2 - Select <strong>GovWifi</strong>. A settings menu appears.</p>
       <%= image_tag "troubleshooting/blackberry-step-2.png", class: "img-fluid" %>

--- a/source/support/connect-to-govwifi-using-a-chromebook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-chromebook.html.erb
@@ -11,7 +11,7 @@ title: Connect a Chromebook - GovWifi
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">Connect a Chromebook</h1>
       <h2 class="heading-medium">Instructions</h2>
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.</p>
       <p>Step 1 - Select the wifi icon in the bottom right of the screen. A list of wifi connections will appear.</p>
       <p>Step 2 - Select <strong>GovWifi</strong>. A settings menu appears.</p>
       <%= image_tag "troubleshooting/chrome-step-2.png", class: "img-fluid" %>

--- a/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
@@ -11,7 +11,7 @@ title: Connect a Mac, iMac or Macbook - GovWifi
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">Connect a Mac, iMac or Macbook</h1>
       <h2 class="heading-medium">Instructions</h2>
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
       <p>Step 1 - Select the wifi icon at the top right of your screen.</p>
       <p>Step 2 - Select <strong>GovWifi</strong>.</p>
       <%= image_tag "troubleshooting/mac-os-step-2.png", class: "img-fluid" %>

--- a/source/support/connect-to-govwifi-using-a-windows-device.html.erb
+++ b/source/support/connect-to-govwifi-using-a-windows-device.html.erb
@@ -24,7 +24,7 @@ title: Connect to GovWifi using a Windows device - GovWifi
 
       <h3 id="connect-windows-8">Connect using Windows 8 or 10</h3>
 
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.</p>
       <p>Step 1 - Select the wifi icon in the system tray at the bottom right of your screen. You'll see all the nearby wifi networks.</p>
 
       <%= image_tag "troubleshooting/windows-step-1.png", class: "img-fluid" %>
@@ -68,7 +68,7 @@ title: Connect to GovWifi using a Windows device - GovWifi
 
       <h2 id="connect-windows-7">Connect using Windows 7</h2>
 
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.</p>
 
       <p>Step 1 - Open the <strong>Control Panel</strong>, and select <strong>Network and Sharing Center</strong>.</p>
       <%= image_tag "troubleshooting/windows-7-step-1.png", class: "img-fluid" %>

--- a/source/support/connect-to-govwifi-using-an-android-device.html.erb
+++ b/source/support/connect-to-govwifi-using-an-android-device.html.erb
@@ -11,7 +11,7 @@ title: Connect an Android device - GovWifi
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">Connect to GovWifi using an Android device</h1>
       <h2 class="heading-medium">Instructions</h2>
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
 
       <p>Step 1 - Open your wifi settings. A list of wifi networks appears.</p>
       <p>Step 2 - Select <strong>GovWifi</strong>. A settings menu appears.</p>

--- a/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
+++ b/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
@@ -11,7 +11,7 @@ title: Connect an iPhone or iPad - GovWifi
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">Connect an iPhone or iPad</h1>
       <h2 class="heading-medium">Instructions</h2>
-      <p>Once you have a GovWifi <%= link_to "username and password", "/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
+      <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
 
       <p>Step 1 - Go to wifi settings and select <strong>GovWifi</strong>.</p>
       <div class="d-flex justify-content-center">

--- a/source/support/connect-visitors-to-govwifi.html.erb
+++ b/source/support/connect-visitors-to-govwifi.html.erb
@@ -20,7 +20,7 @@ title: Visitor access - GovWifi
       </ul>
 
       <div class="govuk-inset-text">
-        <%= link_to "Connect to GovWifi with your government or public sector email address", "/connect-to-govwifi" %>
+        <%= link_to "Connect to GovWifi with your government or public sector email address", "/about-govwifi/connect-to-govwifi" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We moved the `Connect to GovWifi` page into the `about-govwifi ` folder in PR #103 

**IN THIS PR:**
Change any `/connect-to-govwifi` links to `/about-govwifi/connect-to-govwifi`.