### PR TITLE
Ensure all SEO descriptions are present and fixes

### DIFF
--- a/source/about-govwifi/connect-to-govwifi.html.erb
+++ b/source/about-govwifi/connect-to-govwifi.html.erb
@@ -25,7 +25,7 @@ description: Use your government or public sector email address to connect to Go
       <p>We will email your username and password in reply.</p>
       <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
       <div class="govuk-inset-text">
-        <%= link_to "Connect to GovWifi without a government or public sector email address", "/support/connect-visitors-to-govwifi" %>
+        <%= link_to "Connect to GovWifi without a government or public sector email address", "/support/visitor-access-to-govwifi" %>
       </div>
     </div>
   </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,3 +1,8 @@
+---
+title: Guest wifi across the public sector - GovWifi
+description: GovWifi allows staff and visitors to connect to a single secure wifi service across multiple government and public sector organisations
+---
+
 <div class="masthead">
   <div class="hero">
     <div class="hero__content">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,7 +5,7 @@
 
     <meta charset="utf-8">
 
-    <title><%= current_page.data.title && "#{current_page.data.title} – " %>GOV.UK GovWifi</title>
+    <title><%= current_page.data.title && "#{current_page.data.title}" %></title>
 
     <link rel="shortcut icon" href="<%= asset_path :images, 'favicon.ico' %>" type="image/x-icon" />
 

--- a/source/shared/support/_sidebar.html.erb
+++ b/source/shared/support/_sidebar.html.erb
@@ -1,6 +1,7 @@
 <% menu_items = [
   { title: "Govwifi support", link: "/support/" },
-  { title: "Connect visitors to GovWifi", link: "/support/connect-visitors-to-govwifi/" },
+  { title: "Check your organisation email address", link: "support/check-organisation-email-address/" },
+  { title: "Connect to GovWifi as a visitor", link: "/support/visitor-access-to-govwifi/" },
   { title: "Connect an Android device", link: "/support/connect-to-govwifi-using-an-android-device/" },
   { title: "Connect an iPhone or iPad", link: "/support/connect-to-govwifi-using-an-iphone-or-ipad/" },
   { title: "Connect a Mac, iMac or Macbook", link: "/support/connect-to-govwifi-using-a-mac-imac-or-macbook/" },

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Help and support - GovWifi
+description: Help and support connecting to GovWifi
 ---
 <div class="container">
   <div class="grid-row">

--- a/source/support/check-organisation-email-address.html.erb
+++ b/source/support/check-organisation-email-address.html.erb
@@ -13,7 +13,7 @@ description: Check your government or public sector email address to sign up to 
         using your government or public sector email address
       </p>
       <p>If you don't have a government or public sector email address, you can
-        <%= link_to "connect to GovWifi as a visitor", "support/connect-visitors-to-govwifi", class: "govuk-link" %>
+        <%= link_to "connect to GovWifi as a visitor", "support/visitor-access-to-govwifi", class: "govuk-link" %>
       </p>
       <p>You can check to see if your organisation email is eligible below:</p>
       <div class="govuk-form-group govuk-!-margin-bottom-4">

--- a/source/support/connect-to-govwifi-using-a-blackberry.html.erb
+++ b/source/support/connect-to-govwifi-using-a-blackberry.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Connect a Blackberry - GovWifi
+title: Connect to GovWifi using a Blackberry - GovWifi
 description: Follow these instructions to connect your Blackberry to GovWifi
 ---
 

--- a/source/support/connect-to-govwifi-using-a-blackberry.html.erb
+++ b/source/support/connect-to-govwifi-using-a-blackberry.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect a Blackberry - GovWifi
+description: Follow these instructions to connect your Blackberry to GovWifi
 ---
 
 <div class="container">

--- a/source/support/connect-to-govwifi-using-a-chromebook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-chromebook.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Connect a Chromebook - GovWifi
+title: Connect to GovWifi using a Chromebook - GovWifi
 description: Follow these instructions to connect your Chromebook to GovWifi
 ---
 

--- a/source/support/connect-to-govwifi-using-a-chromebook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-chromebook.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect a Chromebook - GovWifi
+description: Follow these instructions to connect your Chromebook to GovWifi
 ---
 
 <div class="container">

--- a/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect a Mac, iMac or Macbook - GovWifi
+description: Follow these instructions to connect your Mac, iMac or Macbook to GovWifi
 ---
 
 <div class="container">

--- a/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Connect a Mac, iMac or Macbook - GovWifi
+title: Connect to GovWifi using a Mac, iMac or Macbook - GovWifi
 description: Follow these instructions to connect your Mac, iMac or Macbook to GovWifi
 ---
 

--- a/source/support/connect-to-govwifi-using-a-windows-device.html.erb
+++ b/source/support/connect-to-govwifi-using-a-windows-device.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect to GovWifi using a Windows device - GovWifi
+description: Follow these instructions to connect your Windows device to GovWifi
 ---
 
 <div class="container">

--- a/source/support/connect-to-govwifi-using-an-android-device.html.erb
+++ b/source/support/connect-to-govwifi-using-an-android-device.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Connect an Android device - GovWifi
+title: Connect to GovWifi using an Android device - GovWifi
 description: Follow these instructions to connect your Android device to GovWifi
 ---
 

--- a/source/support/connect-to-govwifi-using-an-android-device.html.erb
+++ b/source/support/connect-to-govwifi-using-an-android-device.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect an Android device - GovWifi
+description: Follow these instructions to connect your Android device to GovWifi
 ---
 
 <div class="container">

--- a/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
+++ b/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Connect an iPhone or iPad - GovWifi
+title: Connect to GovWifi using an iPhone or iPad - GovWifi
 description: Follow these instructions to connect your iPhone or iPad to GovWifi
 ---
 

--- a/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
+++ b/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Connect an iPhone or iPad - GovWifi
+description: Follow these instructions to connect your iPhone or iPad to GovWifi
 ---
 
 <div class="container">

--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -1,5 +1,6 @@
 ---
 title: Visitor access - GovWifi
+description: Use GovWifi as a visitor to government or public sector organisations
 ---
 <div class="container">
   <div class="grid-row">


### PR DESCRIPTION
Rename connect-visitor-to-govwifi to visitor-access-to-govwifi.
Create subnav link to 'check email' page
Remove Gov.uk from the end of the page titles.