### PR TITLE
Update headings in connect with a device pages

### DIFF
--- a/source/support/connect-to-govwifi-using-a-blackberry.html.erb
+++ b/source/support/connect-to-govwifi-using-a-blackberry.html.erb
@@ -10,7 +10,7 @@ description: Follow these instructions to connect your Blackberry to GovWifi
     </div>
 
     <div class="column-two-thirds column-minimum">
-      <h1 class="heading-large">Connect a Blackberry</h1>
+      <h1 class="heading-large">Connect to GovWifi using a Blackberry</h1>
       <p>If your device was made before October 2016, you're probably running the BlackBerry operating system (OS). Follow these instructions to connect to GovWifi.</p>
 
       <h2 class="heading-medium">Instructions</h2>

--- a/source/support/connect-to-govwifi-using-a-chromebook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-chromebook.html.erb
@@ -10,7 +10,7 @@ description: Follow these instructions to connect your Chromebook to GovWifi
     </div>
 
     <div class="column-two-thirds column-minimum">
-      <h1 class="heading-large">Connect a Chromebook</h1>
+      <h1 class="heading-large">Connect to GovWifi using a Chromebook</h1>
       <h2 class="heading-medium">Instructions</h2>
       <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.</p>
       <p>Step 1 - Select the wifi icon in the bottom right of the screen. A list of wifi connections will appear.</p>

--- a/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
+++ b/source/support/connect-to-govwifi-using-a-mac-imac-or-macbook.html.erb
@@ -10,7 +10,7 @@ description: Follow these instructions to connect your Mac, iMac or Macbook to G
     </div>
 
     <div class="column-two-thirds column-minimum">
-      <h1 class="heading-large">Connect a Mac, iMac or Macbook</h1>
+      <h1 class="heading-large">Connect to GovWifi using a Mac, iMac or Macbook</h1>
       <h2 class="heading-medium">Instructions</h2>
       <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
       <p>Step 1 - Select the wifi icon at the top right of your screen.</p>

--- a/source/support/connect-to-govwifi-using-a-windows-device.html.erb
+++ b/source/support/connect-to-govwifi-using-a-windows-device.html.erb
@@ -10,7 +10,7 @@ description: Follow these instructions to connect your Windows device to GovWifi
     </div>
 
     <div class="column-two-thirds column-minimum">
-      <h1 class="heading-large">Connect a Windows device</h1>
+      <h1 class="heading-large">Connect to GovWifi using a Windows device</h1>
       <h2 class="heading-medium">Instructions</h2>
       <h3 class="heading-small">Contents</h3>
 

--- a/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
+++ b/source/support/connect-to-govwifi-using-an-iphone-or-ipad.html.erb
@@ -10,7 +10,7 @@ description: Follow these instructions to connect your iPhone or iPad to GovWifi
     </div>
 
     <div class="column-two-thirds column-minimum">
-      <h1 class="heading-large">Connect an iPhone or iPad</h1>
+      <h1 class="heading-large">Connect to GovWifi using an iPhone or iPad</h1>
       <h2 class="heading-medium">Instructions</h2>
       <p>Once you have a GovWifi <%= link_to "username and password", "/about-govwifi/connect-to-govwifi" %>, follow the steps below.  Depending on your device, you may need to scroll down to see all the fields.</p>
 


### PR DESCRIPTION
Change headings on all "connect to GovWifi with a DEVICE" pages: https://trello.com/c/i0vUUGiw/26-update-device-support-pages

![Screenshot 2019-04-26 at 15 48 54](https://user-images.githubusercontent.com/2160769/56816181-e754d880-683a-11e9-99d5-d9f5d61f03ff.png)
