### PR TITLE
Add main footer navigation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -66,9 +66,44 @@
       <div class="footer-wrapper">
         <div class="govuk-footer__navigation">
           <div class="govuk-footer__section">
-            <ul class="govuk-footer__list govuk-footer__list--columns-1 footer-link-padding">
+            <h2>About</h2>
+            <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">
-                <a href="https://www.wifi.service.gov.uk/cookies" rel="cookie-policy" class="govuk-footer__link" >Cookies</a>
+                <%= link_to 'Our service', '/about-govwifi' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Terms and conditions', '/terms-and-conditions' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Performance', 'https://www.gov.uk/performance/govwifi' %>
+              </li>
+            </ul>
+          </div>
+          <div class="govuk-footer__section">
+            <h2>Connect</h2>
+            <ul class="govuk-footer__list footer-link-padding">
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Connect to GovWifi', '/about-govwifi/connect-to-govwifi' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Organisations using GovWifi', '/about-govwifi/organisations-using-govwifi' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Support', '/support' %>
+              </li>
+            </ul>
+          </div>
+          <div class="govuk-footer__section">
+            <h2>Admin</h2>
+            <ul class="govuk-footer__list footer-link-padding">
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Offer GovWifi in your organisation', 'https://docs.wifi.service.gov.uk/' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Manage GovWifi in your organisation', 'https://admin.wifi.service.gov.uk/users/sign_in' %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Technical Documentation', 'https://docs.wifi.service.gov.uk/manage/#manage-govwifi' %>
               </li>
             </ul>
           </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -65,7 +65,7 @@
     <footer class="group js-footer" id="footer" role="contentinfo">
       <div class="footer-wrapper">
         <div class="govuk-footer__navigation">
-          <div class="govuk-footer__section">
+          <div class="column-one-third">
             <h2>About</h2>
             <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">
@@ -79,7 +79,7 @@
               </li>
             </ul>
           </div>
-          <div class="govuk-footer__section">
+          <div class="column-one-third">
             <h2>Connect</h2>
             <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">
@@ -93,7 +93,7 @@
               </li>
             </ul>
           </div>
-          <div class="govuk-footer__section">
+          <div class="govuk-footer__section govuk-footer__list--columns-1">
             <h2>Admin</h2>
             <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -64,7 +64,7 @@
 
     <footer class="group js-footer" id="footer" role="contentinfo">
       <div class="footer-wrapper">
-        <div class="govuk-footer__navigation">
+        <div class="govuk-footer__navigation govuk-!-margin-bottom-6">
           <div class="column-one-third">
             <h2>About</h2>
             <ul class="govuk-footer__list footer-link-padding">
@@ -93,7 +93,7 @@
               </li>
             </ul>
           </div>
-          <div class="govuk-footer__section govuk-footer__list--columns-1">
+          <div class="column-one-third">
             <h2>Admin</h2>
             <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -3,6 +3,7 @@
 @import "govuk-frontend/components/inset-text/inset-text";
 @import "govuk-frontend/components/input/input";
 @import "govuk-frontend/overrides/spacing";
+@import "govuk-frontend/components/footer/footer";
 
 @import "govuk_frontend_toolkit/stylesheets/colours";
 @import "govuk_frontend_toolkit/stylesheets/conditionals";

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -5,6 +5,7 @@
 }
 
 .footer-link-padding {
+  padding-top: 20px;
   padding-left: 0px;
   font-size: 16px;
 }


### PR DESCRIPTION
- Add main footer navigation as described in the [spreadsheet](https://docs.google.com/spreadsheets/d/141spueIa6sG7Eyv6EjsqFn8s4ubJ8YX0LzpS0kGT91Q/edit#gid=696358261).

- Add styling as necessary

BEFORE:

<img width="1118" alt="Screenshot 2019-04-29 at 10 48 04" src="https://user-images.githubusercontent.com/32823756/56888604-4b121800-6a6c-11e9-9a9f-d4e23decd880.png">

------------------------------------------------------------------------------------------------------

AFTER:
<img width="1168" alt="Screenshot 2019-04-29 at 10 43 35" src="https://user-images.githubusercontent.com/32823756/56888567-3b92cf00-6a6c-11e9-8ce0-7d2b0f98e757.png">

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**