### PR TITLE
Hide search bar when js disabled

### DIFF
--- a/source/about-govwifi/organisations-using-govwifi.html.erb
+++ b/source/about-govwifi/organisations-using-govwifi.html.erb
@@ -48,3 +48,4 @@ description: Find all the public sector organisations where GovWifi is available
 </div>
 
 <%= partial 'shared/dynamic_search_bar' %>
+<%= partial 'shared/dynamic_search_bar_noscript' %>

--- a/source/shared/_dynamic_search_bar_noscript.html.erb
+++ b/source/shared/_dynamic_search_bar_noscript.html.erb
@@ -1,0 +1,5 @@
+<noscript>
+  <style>
+    #search-table { display:none; }
+  </style>
+</noscript>

--- a/source/support/check-organisation-email-address.html.erb
+++ b/source/support/check-organisation-email-address.html.erb
@@ -45,3 +45,4 @@ description: Check your government or public sector email address to sign up to 
   </div>
 </div>
 <%= partial 'shared/dynamic_search_bar' %>
+<%= partial 'shared/dynamic_search_bar_noscript' %>


### PR DESCRIPTION
**WHY:**
When the pages with the dynamic search bar are viewed in a browser with Javascript disabled, the input field is still present and not interactive. 
For better accessibility, it was suggested to hide the input field whenever JS is disabled.

**IN THIS PR:**
- Add no script tags and display style into separate `html.erb` file
- Add no script partial to the pages with the dynamic search bar.

**BEFORE (View when JS is disabled, note the visibility of the input field above the blue header):**

_1. Search Org Email_

<img width="650" alt="Screenshot 2019-04-29 at 15 16 23" src="https://user-images.githubusercontent.com/32823756/56902685-b242c300-6a92-11e9-9573-46d038b320d8.png">


_2. Search Org name_

<img width="657" alt="Screenshot 2019-04-29 at 15 16 37" src="https://user-images.githubusercontent.com/32823756/56902729-cb4b7400-6a92-11e9-9f32-ef5bb7807a14.png">


------------------------------------------------------------------------------------------------------

**AFTER (View when JS is disabled, note the input field is not present anymore):**

_1. Search Org Email_

<img width="644" alt="Screenshot 2019-04-29 at 15 15 56" src="https://user-images.githubusercontent.com/32823756/56902797-ec13c980-6a92-11e9-875b-7d49300e1115.png">


_2. Search Org name_

<img width="668" alt="Screenshot 2019-04-29 at 15 15 46" src="https://user-images.githubusercontent.com/32823756/56902812-f5049b00-6a92-11e9-90e2-f14bfac7571c.png">


------------------------------------------------------------------------------------------------------
**Any feedback/suggestions would be appreciated.**