### PR TITLE
Update content on connect to govwifi page

### DIFF
--- a/source/about-govwifi/connect-to-govwifi.html.erb
+++ b/source/about-govwifi/connect-to-govwifi.html.erb
@@ -20,19 +20,22 @@ description: Use your government or public sector email address to connect to Go
         You can check if your <%= link_to "government or public sector organisation email address",
         "/support/check-organisation-email-address" %> is eligible for GovWifi.
       </p>
+      <p>
+        Before using GovWifi, please read and accept our <%= link_to "privacy notice", "/privacy-notice" %> and <%= link_to "terms and conditions", "/terms-and-conditions" %>.
+      </p>
       <div>
+        <h2>Get Started</h2>
         <p>You will need to use your government or public sector organisation email address to:</p>
         <ul class="list list-bullet">
           <li>send a blank email to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %></li>
           <li>leave the subject line blank</li>
-          <li>
-            read and accept the <%= link_to "terms and conditions", "/terms-and-conditions" %>,
-            and our <%= link_to "privacy notice", "/privacy-notice" %>.
-          </li>
         </ul>
       </div>
       <p>We will email your username and password in reply.</p>
       <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
+      <p>
+        If you experience any problems connecting to GovWifi for the first time, please review our <%= link_to "support guides", "/support" %>.
+      </p>
       <div class="govuk-inset-text">
         <%= link_to "Connect to GovWifi without a government or public sector email address", "/support/visitor-access-to-govwifi", class: "bold" %>
       </div>


### PR DESCRIPTION
**WHY:**

Content on the **Connect to GovWifi** page required some changes detailed in the design [spreadsheet](https://docs.google.com/spreadsheets/d/141spueIa6sG7Eyv6EjsqFn8s4ubJ8YX0LzpS0kGT91Q/edit#gid=2026950949).

**IN THIS PR:**

- Make T&C's more explicit and place above **Get Started** process. 
- Add new heading
- Add signpost to support within **Get Started** body

**NEW DISPLAY:**

![Screenshot 2019-04-30 at 10 00 46](https://user-images.githubusercontent.com/32823756/56951277-495d5880-6b2f-11e9-8ad0-e01299bf1350.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**