### PR TITLE
Update content in How GovWifi works page

### DIFF
--- a/source/about-govwifi/how-govwifi-works.html.erb
+++ b/source/about-govwifi/how-govwifi-works.html.erb
@@ -11,7 +11,7 @@ description: Learn more about how the GovWifi authenication service works.
       </div>
     </div>
     <div class="column-two-thirds">
-      <h1 class="heading-large">How does GovWifi work</h1>
+      <h1 class="heading-large">How GovWifi works</h1>
       <p>
         Participating government and public organisations keep their existing wifi infrastructure and configure it to access the GovWifi authentication service.
       </p>
@@ -27,14 +27,8 @@ description: Learn more about how the GovWifi authenication service works.
         Users’ devices are isolated from each other to stop the horizontal spread of malware and protect secure devices from less secure ones.
         The network also identifies itself in a way that can’t be spoofed, adding to the safety measures that provide protection from potential attackers.
       </p>
-      <div class="govuk-inset-text">
-        <p>
-          If you are trying to connect your device to GovWifi please follow these <%= link_to "sign up instructions.", "/about-govwifi/connect-to-govwifi", class: "bold" %>
-        </p>
-      </div>
-      <h2>Offer GovWifi in your organisation</h2>
       <p>
-        If you manage IT services in your organisation and would like to make GovWifi available in your buildings, please review our <%= link_to "administrator requirements", "https://docs.wifi.service.gov.uk/" %>.
+        Follow our <%= link_to "sign up instructions", "/about-govwifi/connect-to-govwifi", class: "bold" %>  to connect to GovWifi.
       </p>
     </div>
   </div>

--- a/source/about-govwifi/how-govwifi-works.html.erb
+++ b/source/about-govwifi/how-govwifi-works.html.erb
@@ -27,9 +27,11 @@ description: Learn more about how the GovWifi authenication service works.
         Users’ devices are isolated from each other to stop the horizontal spread of malware and protect secure devices from less secure ones.
         The network also identifies itself in a way that can’t be spoofed, adding to the safety measures that provide protection from potential attackers.
       </p>
-      <p>
-        Follow our <%= link_to "sign up instructions", "/about-govwifi/connect-to-govwifi", class: "bold" %>  to connect to GovWifi.
-      </p>
+      <div class="govuk-inset-text">
+        <p>
+          Follow our <%= link_to "sign up instructions", "/about-govwifi/connect-to-govwifi", class: "bold" %>  to connect to GovWifi.
+        </p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**WHY:**

Content on the **How GovWifi works** page required some changes detailed in the design [spreadsheet](https://docs.google.com/spreadsheets/d/141spueIa6sG7Eyv6EjsqFn8s4ubJ8YX0LzpS0kGT91Q/edit#gid=1116247888).

**IN THIS PR:**

- Change `<h1>` header text
- Remove **offer GovWifi** section
- Change call out text

**NEW DISPLAY:**

![Screenshot 2019-04-30 at 10 48 10](https://user-images.githubusercontent.com/32823756/56954016-a9ef9400-6b35-11e9-9277-a87c900018b4.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**