### PR TITLE
REMOVE search icons to search bars

### DIFF
--- a/source/about-govwifi/organisations-using-govwifi.html.erb
+++ b/source/about-govwifi/organisations-using-govwifi.html.erb
@@ -19,6 +19,7 @@ description: Find all the public sector organisations where GovWifi is available
       </p>
 
       <div class="govuk-form-group govuk-!-margin-bottom-4">
+        <span class="fa fa-search"></span>
         <input class="govuk-input" aria-label="Search organisations using the service" id="search-table" type="text" placeholder="Search organisations">
       </div>
 

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -94,6 +94,19 @@ body {
   width: 165%;
 }
 
+@import url("//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css");
+.govuk-form-group { position: relative; }
+.govuk-form-group .fa-search {
+  position: absolute;
+  top: 10px;
+  right: 0px;
+  font-size: 29px;
+  background-color: #005ea5;
+  color: white;
+  padding: 4.5px 10px 7px 12px;
+  margin-top: -10px;
+}
+
 .privacy_policy_nav_colour {
   background-color: govuk-colour("white")
 }

--- a/source/support/check-organisation-email-address.html.erb
+++ b/source/support/check-organisation-email-address.html.erb
@@ -17,6 +17,7 @@ description: Check your government or public sector email address to sign up to 
       </p>
       <p>You can check to see if your organisation email is eligible below:</p>
       <div class="govuk-form-group govuk-!-margin-bottom-4">
+        <span class="fa fa-search"></span>
         <input class="govuk-input" aria-label="Search for eligible organisation emails" id="search-table" type="text" placeholder="Search email domains">
       </div>
 


### PR DESCRIPTION
PURPOSE: To follow the design system guidelines by adding a search icon for accessibility. This has been done for both `organisations-using-govwifi` & `check-organisation-email-address` pages

![Screenshot 2019-04-30 at 11 29 09](https://user-images.githubusercontent.com/40758489/56956175-48cabf00-6b3b-11e9-9313-d730e15bacf3.png)
