### PR TITLE
Update product page support content

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -11,26 +11,31 @@ description: Help and support connecting to GovWifi
     <div class="column-two-thirds">
       <h1 class="heading-large">GovWifi support</h1>
 
-      <h2 class="heading-medium">GovWifi support</h2>
+      <h2 class="heading-medium">User support</h2>
+      <p>
+        Use the left-hand navigation bar to view our support guides for assistance in connecting to GovWifi for the first time.
+      </p>
+      <p>
+        If you experience any problems with your username or password,
+        please <%= link_to "contact us", "https://admin.wifi.service.gov.uk/help/new/user_support", class: "govuk-link" %>.
+      </p>
       <p>
         GovWifi access in your building is provided by the participating
         government or public sector organisation.
       </p>
       <p>
-        If you experience any problems with wifi access, please contact the
-        relevant organisation IT Support team.
+        If you can’t see the GovWifi network in your wifi settings or experience any problems with wifi connectivity,
+        please contact the relevant organisation IT Support team.
       </p>
       <p>
-        You can check which government or public sector organisations currently
-        <%= link_to "offer GovWifi.", "/about-govwifi/organisations-using-govwifi",
-        class: "govuk-link" %>
+        You can check which <%= link_to "government or public sector organisations", "/about-govwifi/organisations-using-govwifi", class: "govuk-link" %> currently offer GovWifi.
       </p>
 
       <h2 class="heading-medium">Network administrator support</h2>
       <p>
         If you manage public sector IT services and require support setting up a
         new or managing an existing GovWifi installation, please
-        <%= link_to "contact us.", "https://admin.wifi.service.gov.uk/help", class: "govuk-link" %>
+        <%= link_to "contact us", "https://admin.wifi.service.gov.uk/help", class: "govuk-link" %>.
       </p>
       <p>
         The Government Digital Service (GDS) maintains the service behind GovWifi


### PR DESCRIPTION
**WHY:**

Content on the GovWifi support page required some changes detailed in the design [spreadsheet](https://docs.google.com/spreadsheets/d/141spueIa6sG7Eyv6EjsqFn8s4ubJ8YX0LzpS0kGT91Q/edit#gid=1608488907).

**IN THIS PR:**

- Add beginning content
- Add link to admin portal support feedback form
- Change hypertext from **_offer GovWifi_** to **_government or public sector organisations_** 
- Remove full stop from hyperlink

**BEFORE:**

![Screenshot 2019-04-30 at 15 17 28](https://user-images.githubusercontent.com/32823756/56968470-1a5cdc00-6b5b-11e9-9d14-edf0a40a7355.png)


**AFTER:**

![Screenshot 2019-04-30 at 15 10 10](https://user-images.githubusercontent.com/32823756/56968415-06b17580-6b5b-11e9-8a06-95a0876431e3.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**