### PR TITLE
Fix the `mailto` syntax

### DIFF
--- a/source/about-govwifi/connect-to-govwifi.html.erb
+++ b/source/about-govwifi/connect-to-govwifi.html.erb
@@ -27,7 +27,7 @@ description: Use your government or public sector email address to connect to Go
         <h2>Get Started</h2>
         <p>You will need to use your government or public sector organisation email address to:</p>
         <ul class="list list-bullet">
-          <li>send a blank email to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %></li>
+          <li>send a blank email to <%= link_to "signup@wifi.service.gov.uk", "mailto:signup@wifi.service.gov.uk" %></li>
           <li>leave the subject line blank</li>
         </ul>
       </div>

--- a/source/privacy-notice.html.erb
+++ b/source/privacy-notice.html.erb
@@ -150,7 +150,7 @@ description: Find details about the GovWifi privacy policy and how we collect an
       <p>
         Email
         <br/>
-        <%= link_to "DPO@cabinetoffice.gov.uk", "mailto: DPO@cabinetoffice.gov.uk" %>
+        <%= link_to "DPO@cabinetoffice.gov.uk", "mailto:DPO@cabinetoffice.gov.uk" %>
       </p>
       <p>
         If you have a complaint, you can also contact the <%= link_to "Information Commissioner", "https://ico.org.uk" %>, who is an independent regulator set up to uphold information rights.
@@ -170,7 +170,7 @@ description: Find details about the GovWifi privacy policy and how we collect an
       <p>
         Email
         <br/>
-        <%= link_to "casework@ico.org.uk", "mailto: casework@ico.org.uk" %>
+        <%= link_to "casework@ico.org.uk", "mailto:casework@ico.org.uk" %>
       </p>
       <p>
         Contact form

--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -26,7 +26,7 @@ description: Use GovWifi as a visitor to government or public sector organisatio
       <p>The staff member will need to use their public sector email address to:</p>
 
       <ul class="list list-bullet">
-        <li>send an email to <%= link_to "sponsor@wifi.service.gov.uk", "mailto: sponsor@wifi.service.gov.uk" %></li>
+        <li>send an email to <%= link_to "sponsor@wifi.service.gov.uk", "mailto:sponsor@wifi.service.gov.uk" %></li>
         <li>leave the subject line blank</li>
         <li>only include the email address of each visitor on separate lines within the email</li>
       </ul>


### PR DESCRIPTION
## What

There is a problem when copying the email address from these hrefs, that
adds `%20` where there is a space.

These are unnecessary spaces and don't add value.

## How

- Sanity check
- Run locally and attempt to copy an email address
  - Expect no weird characters