### PR TITLE
Update homepage with clearer content on 'signing up' for GovWifi and add CTA button to connect content

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -7,7 +7,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
   <div class="hero">
     <div class="hero__content">
       <div class="hero__body">
-        <h1 class="hero__title">Connect to the public sector guest wifi network</h1>
+        <h1 class="hero__title">Public sector guest wifi</h1>
         <div class="hero__inline-image">
           <img src="/images/Product-illustration.png" alt="" role="presentation" width="100%">
         </div>
@@ -15,6 +15,9 @@ description: GovWifi allows staff and visitors to use a single user login to con
           GovWifi allows staff and visitors to use a single user login to connect
           to guest wifi across multiple government and public sector organisations.
         </p>
+        <a href="https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/" role="button" class="hero-button" data-click-events="" data-click-category="Hero" data-click-action="Button clicked">
+                    Connect to GovWifi
+       </a>
       </div>
       <div class="hero__aside-image main-image">
         <img src="/images/Product-illustration.png" alt="govwifi-image" role="presentation" width="100%">
@@ -26,9 +29,9 @@ description: GovWifi allows staff and visitors to use a single user login to con
 <div class="container">
   <div class="grid-row">
     <div class="column-one-third">
-      <h2>Access GovWifi</h2>
+      <h2>Sign up to GovWifi</h2>
       <p>Sign up to connect your device to the GovWifi network across the public sector.</p>
-      <%= link_to "Connect your device", "/about-govwifi/connect-to-govwifi/", class: "govuk-link bold" %>
+      <%= link_to "Sign up to GovWifi", "/about-govwifi/connect-to-govwifi/", class: "govuk-link bold" %>
     </div>
 
     <div class="column-one-third">


### PR DESCRIPTION
- make proposition more succinct
- include CTA for connect to GovWifi
- make clear that users have to 'sign up' in order to connect devices