### PR TITLE
[Discuss] Move network admin support content to separate page

### DIFF
--- a/source/shared/support/_sidebar.html.erb
+++ b/source/shared/support/_sidebar.html.erb
@@ -7,7 +7,8 @@
   { title: "Connect a Mac, iMac or Macbook", link: "/support/connect-to-govwifi-using-a-mac-imac-or-macbook/" },
   { title: "Connect a Windows device", link: "/support/connect-to-govwifi-using-a-windows-device/" },
   { title: "Connect a Chromebook", link: "/support/connect-to-govwifi-using-a-chromebook/" },
-  { title: "Connect a Blackberry", link: "/support/connect-to-govwifi-using-a-blackberry/" }
+  { title: "Connect a Blackberry", link: "/support/connect-to-govwifi-using-a-blackberry/" },
+  { title: "Network administrator support", link: "/support/network-administrator-support/" }
 ] %>
 
 <nav class="sub-navigation">

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -23,14 +23,7 @@ description: Help and support connecting to GovWifi
       </p>
       <h2 class="heading-medium">Network administrator support</h2>
       <p>
-        If you manage public sector IT services and require support setting up a
-        new or managing an existing GovWifi installation, please
-        <%= link_to "contact us", "https://admin.wifi.service.gov.uk/help", class: "govuk-link" %>.
-      </p>
-      <p>
-        The Government Digital Service (GDS) maintains the service behind GovWifi
-        and helps network administrators to set up or manage existing GovWifi
-        installation in their organisation.
+        Please read our <%= link_to "Network administrator support guidance", "/support/network-administrator-support/" %>.
       </p>
     </div>
   </div>

--- a/source/support/network-administrator-support.html.erb
+++ b/source/support/network-administrator-support.html.erb
@@ -1,0 +1,28 @@
+---
+title: Network administrator support - GovWifi
+description: Govwifi support request for network administrators
+---
+<div class="container">
+  <%= partial "shared/support/breadcrumbs", locals: { page: "Network administrator support" } %>
+
+  <div class="grid-row">
+    <div class="column-one-third">
+      <%= partial '/shared/support/_sidebar' %>
+    </div>
+
+    <div class="column-two-thirds column-minimum">
+
+      <h1 class="heading-large">Network administrator support</h1>
+        <p>
+          If you manage public sector IT services and require support setting up a
+          new or managing an existing GovWifi installation, please
+          <%= link_to "contact us", "https://admin.wifi.service.gov.uk/help", class: "govuk-link" %>.
+        </p>
+        <p>
+          The Government Digital Service (GDS) maintains the service behind GovWifi
+          and helps network administrators to set up or manage existing GovWifi
+          installation in their organisation.
+        </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Moves the network administrator content to its own page.

We believe an increased number of support requests are coming from the 'contact us' link within this content. So making this a separate page specific to network admins may help *end users* find the right route to support via their local network admins.

### Main support page

![Screenshot from 2019-06-13 11-51-41](https://user-images.githubusercontent.com/93511/59427475-a73dbb00-8dd2-11e9-9c55-83dc13544553.png)


### Network admin support page

![Screenshot from 2019-06-13 11-55-47](https://user-images.githubusercontent.com/93511/59427520-bcb2e500-8dd2-11e9-95ca-1834e49ccfa1.png)
