### PR TITLE
Make T&CS more explicit & spam folder awareness

### DIFF
--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -17,7 +17,7 @@ description: Use GovWifi as a visitor to government or public sector organisatio
         you can connect to GovWifi as a visitor.
       </p>
       <p>
-        Before using GovWifi, please read and accept our <%= link_to "privacy notice", "/privacy-notice" %> and <%= link_to "terms and conditions", "/terms-and-conditions" %>.
+        By connecting to GovWifi, you accept our <%= link_to "privacy notice", "/privacy-notice" %> and <%= link_to "terms and conditions", "/terms-and-conditions" %>.
       </p>
       <h2>Get Started</h2>
       <p>
@@ -32,6 +32,9 @@ description: Use GovWifi as a visitor to government or public sector organisatio
         <li>leave the subject line blank</li>
         <li>only include the email address of each visitor on separate lines within the email</li>
       </ul>
+       <p>
+        Once this has been done, you will receive an email containing your username and password. If you do not receive the confirmation message within a few minutes of signing up, please check your spam/junk e-mail folder.
+      </p>
 
       <div class="govuk-inset-text">
         <%= link_to "Connect to GovWifi with your government or public sector email address", "/about-govwifi/connect-to-govwifi", class: "bold" %>


### PR DESCRIPTION
We need to make clear to non public sector staff that they are accepting our T&Cs by connecting to GovWifi. In addition we need to provide guidance on what to expect once they have been sponsored.