### PR TITLE
Make password reminder info clearer

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -18,19 +18,15 @@ description: Help and support connecting to GovWifi
         Use the left-hand navigation bar to view our support guides for assistance in connecting to GovWifi for the first time.
       </p>
       <p>
-        If you need a username or password reminder, please send a blank email from your
-        government or public sector email address to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %>.
+        If you need a username or password reminder, please send a blank email from the email address you registered with to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %>.
       </p>
+        <p>
+        For additional support, please contact the IT support desk in your building. They will be able to check your device and also ensure the local network is working. 
+      </p>
+      
       <h2 class="heading-medium">Network administrator support</h2>
       <p>
-        If you manage public sector IT services and require support setting up a
-        new or managing an existing GovWifi installation, please
-        <%= link_to "contact us", "https://admin.wifi.service.gov.uk/help", class: "govuk-link" %>.
-      </p>
-      <p>
-        The Government Digital Service (GDS) maintains the service behind GovWifi
-        and helps network administrators to set up or manage existing GovWifi
-        installation in their organisation.
+        We provide network administrator guidance on how to install and manage GovWifi in your organisation in our <%= link_to "technical documentation", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
We've had feedback that current guidance is unclear how non-government users can get password reminders, so we need to address this. In addtion we need to make clear end-users should contact local IT helpdesk for support, and network admins should review our tech docs for support in the first instance.