### PR TITLE
Update homepage hero descripion

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -12,8 +12,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
           <img src="/images/Product-illustration.png" alt="" role="presentation" width="100%">
         </div>
         <p class="hero__description">
-          GovWifi allows staff and visitors to use a single user login to connect
-          to guest wifi across multiple government and public sector organisations.
+          GovWifi is a wifi authentication service allowing staff and visitors to use a single user login to connect to guest wifi across the public sector.
         </p>
         <a href="https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/" role="button" class="hero-button" data-click-events="" data-click-category="Hero" data-click-action="Button clicked">
                     Connect to GovWifi


### PR DESCRIPTION
Need to make clear on the homepage that that service/proposition is a wifi authentication service. This is necessary to tackle misinterpretations that we offer other wifi services