### PR TITLE
Add SEO steps as json for connecting to GovWifi

### DIFF
--- a/source/about-govwifi/connect-to-govwifi.html.erb
+++ b/source/about-govwifi/connect-to-govwifi.html.erb
@@ -40,3 +40,68 @@ description: Use your government or public sector email address to connect to Go
     </div>
   </div>
 </div>
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "HowTo",
+  "name": "Connect to GovWifi",
+  "description": "Use your government or public sector email address to connect to GovWifi.",
+  "requirements": [{
+    "@type": "HowToTool",
+    "name": "Government or public sector email address"
+  }],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "url": "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/",
+      "name": "Sign up for GovWifi account",
+      "itemListElement": [
+        {
+          "@type": "HowToDirection",
+          "text": "Use your government or public sector email address to send a blank email to signup@wifi.service.gov.uk."
+        },
+        {
+          "@type": "HowToDirection",
+          "text": "Leave the email subject line blank."
+        }
+      ]
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Receive GovWifi instructions",
+      "url": "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/",
+      "itemListElement": [
+        {
+          "@type": "HowToTip",
+          "text": "You will receive an email with your GovWifi username and password."
+        },
+        {
+          "@type": "HowToDirection",
+          "text": "Please check your spam/junk mail folder if you haven't received the email."
+        }
+      ]
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Update your device wifi settings",
+      "url": "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/",
+      "itemListElement": [
+        {
+          "@type": "HowToDirection",
+          "text": "Once you have your GovWifi username and password, go to your wifi settings and select GovWifi."
+        },
+        {
+          "@type": "HowToDirection",
+          "text": "Enter the GovWifi username and password you received by email."
+        },
+        {
+          "@type": "HowToDirection",
+          "text": "Follow our support guide for additional device specific instructions https://www.wifi.service.gov.uk/support"
+        }
+      ]
+    }
+  ],
+  "totalTime": "PT10M"
+}
+</script>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -46,3 +46,53 @@ description: GovWifi allows staff and visitors to use a single user login to con
     </div>
   </div>
 </div>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "name": "GovWifi",
+  "brand": "GovWifi",
+  "alternateName": "Gov Wifi",
+  "audience": "UK public sector staff and visitors",
+  "slogan": "UK Public sector guest wifi",
+  "potentialAction": "Connect to GovWifi",
+  "serviceType": "Network connectivity",
+  "serviceOutput": "GovWifi uses RADIUS server technology to authenticate users’ usernames and passwords. Participating public sector organisations keep their existing wifi infrastructure and configure it to access the GovWifi authentication service.",
+  "description": "GovWifi is a wifi authentication service allowing staff and visitors to use the same credentials (username and password) to connect to guest wifi across UK public sector organisations.",
+  "url": "https://www.wifi.service.gov.uk/",
+  "mainEntityOfPage": "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/",
+  "logo": "https://www.wifi.service.gov.uk/images/Product-illustration.png",
+  "serviceArea": {
+    "@type": "Place",
+    "name": "United Kingdom"
+  },
+  "availableChannel": {
+    "@type": "serviceChannel",
+    "serviceUrl": "https://www.wifi.service.gov.uk/",
+    "servicePostalAddress": "10 Whitechapel High Street, London, E1 8QS"
+  },
+  "provider": {
+    "@type": "Organization",
+    "name": "Government Digital Service (UK)",
+    "url": "https://www.gov.uk/government/organisations/government-digital-service"
+  },
+  "category": {
+    "@type": "Service",
+    "name": "Government service"
+  },
+  "termsOfService": "https://www.wifi.service.gov.uk/terms-and-conditions/",
+  "sameAs": [
+    "https://www.gov.uk/government/publications/govwifi/govwifi",
+    "https://www.gov.uk/government/publications/govwifi/govwifi#how-govwifi-works",
+    "https://www.gov.uk/government/publications/govwifi/govwifi#availability-and-support",
+    "https://www.gov.uk/performance/govwifi",
+    "https://gds.blog.gov.uk/2019/02/12/govwifi-connecting-your-organisation-is-now-easier-than-ever/",
+    "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/",
+    "https://www.wifi.service.gov.uk/about-govwifi/organisations-using-govwifi/",
+    "https://www.wifi.service.gov.uk/about-govwifi/",
+    "https://www.wifi.service.gov.uk/about-govwifi/how-govwifi-works/",
+    "https://gds.blog.gov.uk/2017/09/19/govwifi-ready-to-make-more-connections/"
+  ]
+}
+</script>


### PR DESCRIPTION
https://trello.com/c/KdulswMB/167-implement-technical-seo-for-connect-to-govwifi-page

- Adds SEO information as json for Govwifi homepage
- Adds HowTo steps for connecting to GovWifi as json data, this is read by crawlers to construct a search result step-by-step guide.