### PR TITLE
Update connect instructions for public sector staff

### DIFF
--- a/source/about-govwifi/connect-to-govwifi.html.erb
+++ b/source/about-govwifi/connect-to-govwifi.html.erb
@@ -1,6 +1,6 @@
 ---
 title: Connect to GovWifi - GovWifi
-description: Use your government or public sector email address to connect to GovWifi.
+description: Use your public sector staff email address to connect to GovWifi.
 ---
 
 <div class="container">
@@ -15,28 +15,40 @@ description: Use your government or public sector email address to connect to Go
     <div class="column-two-thirds">
       <h1 class="heading-large">Connect to GovWifi</h1>
       <p>
-        You need a <%= link_to "government or public sector organisation email address",
-        "/support/check-organisation-email-address" %>, to sign up to get your unique username and password for GovWifi.
+        You need a <%= link_to "public sector staff email address",
+        "/support/check-organisation-email-address" %> to sign up for a GovWifi account.
       </p>
-      <p>
-        By connecting to GovWifi, you accept our <%= link_to "privacy notice", "/privacy-notice" %> and <%= link_to "terms and conditions", "/terms-and-conditions" %>.
+       <p>
+        If you do not have a public sector staff email address, you can <%= link_to "connect to GovWifi as a visitor",
+        "/support/visitor-access-to-govwifi" %>.
       </p>
+      <div class="govuk-inset-text">
+         By connecting to GovWifi, you accept our <a href="https://www.wifi.service.gov.uk/privacy-notice">privacy notice</a> and <a href="https://www.wifi.service.gov.uk/terms-and-conditions">terms and conditions</a>.  
+      </div>
       <div>
-        <h2>Get Started</h2>
-        <p>You will need to use your government or public sector organisation email address to:</p>
+        <h2>1. Sign up for a GovWifi account</h2>
+        <p>Create a GovWifi account by using your public sector staff email address to:</p>
         <ul class="list list-bullet">
           <li>send a blank email to <%= link_to "signup@wifi.service.gov.uk", "mailto:signup@wifi.service.gov.uk" %></li>
           <li>leave the subject line blank</li>
         </ul>
       </div>
-      <p>We will email your username and password confirmation in reply. If you do not receive the confirmation message within a few minutes of signing up, please check your spam/junk e-mail folder.</p>
-      <p>Once you’re set up, you can use the same username and password on all the devices you connect to GovWifi.</p>
-      <p>
-        If you experience any problems connecting to GovWifi for the first time, please review our <%= link_to "support guides", "/support" %>.
-      </p>
-      <div class="govuk-inset-text">
-        <%= link_to "Connect to GovWifi without a government or public sector email address", "/support/visitor-access-to-govwifi", class: "bold" %>
+      <p>We will email your username and password confirmation in reply.</p> 
+      <p>If you do not receive the username and password confirmation e-mail within a few minutes of signing up, please check your spam/junk e-mail folder.</p>
+ 	   <div>
+        <h2>2. Connect your device to GovWifi</h2>
+        <p>When you are in a <%= link_to "organisation that offers GovWifi",
+        "/about-govwifi/organisations-using-govwifi" %>, follow the steps below to connect your device:</p>
+        <ul class="list list-bullet">
+          <li>go to your device wifi settings and select GovWifi.</li>
+		  <li>enter the GovWifi username and password you received by email.</li>
+		  <li>your password is case sensitive. It’s 3 words without spaces. The first letter of each word is capitalised.</li>
+		  <li>you can use the same username and password on all the devices you connect to GovWifi.</li> 
+        </ul>
       </div>
+      <p>
+        Please review our <a href="https://www.wifi.service.gov.uk/support">support guides</a> for device specific instructions.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Need to make clearer the steps between getting username and password for Govwifi and then connecting your device to GovWifi