### PR TITLE
Make visitor signup steps clearer

### DIFF
--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -43,9 +43,9 @@ description: Use GovWifi as a visitor to public sector organisations
         "/about-govwifi/organisations-using-govwifi" %>, follow the steps below to connect your device:</p>
         <ul class="list list-bullet">
           <li>go to your device wifi settings and select GovWifi.</li>
-		  <li>enter the GovWifi username and password you received by email.</li>
-		  <li>your password is case sensitive. It’s 3 words without spaces. The first letter of each word is capitalised.</li>
-		  <li>you can use the same username and password on all the devices you connect to GovWifi.</li> 
+	  <li>enter the GovWifi username and password you received by email.</li>
+	  <li>your password is case sensitive. It’s 3 words without spaces. The first letter of each word is capitalised.</li>
+          <li>you can use the same username and password on all the devices you connect to GovWifi.</li> 
         </ul>
       </div>
       

--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -1,6 +1,6 @@
 ---
 title: Visitor access - GovWifi
-description: Use GovWifi as a visitor to public sector organisations
+description: Access GovWifi as a visitor to public sector organisations
 ---
 <div class="container">
   <%= partial "shared/support/breadcrumbs", locals: { page: "Connect to GovWifi as a visitor" } %>

--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -33,7 +33,7 @@ description: Use GovWifi as a visitor to public sector organisations
         <li>only include the email address of each visitor on separate lines within the email</li>
       </ul>
       </div>
-      
+       
        <p>Once this has been done, you will receive an email containing your GovWifi username and password.</p> 
        <p>If you do not receive the username and password confirmation e-mail within a few minutes of signing up, please check your spam/junk e-mail folder.</p>
 

--- a/source/support/visitor-access-to-govwifi.html.erb
+++ b/source/support/visitor-access-to-govwifi.html.erb
@@ -1,6 +1,6 @@
 ---
 title: Visitor access - GovWifi
-description: Use GovWifi as a visitor to government or public sector organisations
+description: Use GovWifi as a visitor to public sector organisations
 ---
 <div class="container">
   <%= partial "shared/support/breadcrumbs", locals: { page: "Connect to GovWifi as a visitor" } %>
@@ -13,32 +13,46 @@ description: Use GovWifi as a visitor to government or public sector organisatio
     <div class="column-two-thirds column-minimum">
       <h1 class="heading-large">Connect to GovWifi as a visitor</h1>
       <p>
-        If you do not have a <%= link_to "government or public sector email address", "/support/check-organisation-email-address" %>,
+        If you do not have a <%= link_to "public sector staff email address", "/support/check-organisation-email-address" %>,
         you can connect to GovWifi as a visitor.
       </p>
-      <p>
-        By connecting to GovWifi, you accept our <%= link_to "privacy notice", "/privacy-notice" %> and <%= link_to "terms and conditions", "/terms-and-conditions" %>.
-      </p>
-      <h2>Get Started</h2>
-      <p>
-        You will need to contact the public sector staff member you are visiting
-        to sponsor your access to GovWifi.
-      </p>
+      
+      <div class="govuk-inset-text">
+         By connecting to GovWifi, you accept our <a href="https://www.wifi.service.gov.uk/privacy-notice">privacy notice</a> and <a href="https://www.wifi.service.gov.uk/terms-and-conditions">terms and conditions</a>.  
+      </div>
 
-      <p>The staff member will need to use their public sector email address to:</p>
-
+      <div>
+      <h2>1. Get sponsored by public sector staff</h2>
+      <p>
+        You will need a public sector staff member to sponsor your access to GovWifi.
+      </p>
+      <p>The staff member will need to use their public sector staff email address to:</p>
       <ul class="list list-bullet">
         <li>send an email to <%= link_to "sponsor@wifi.service.gov.uk", "mailto:sponsor@wifi.service.gov.uk" %></li>
         <li>leave the subject line blank</li>
         <li>only include the email address of each visitor on separate lines within the email</li>
       </ul>
-       <p>
-        Once this has been done, you will receive an email containing your username and password. If you do not receive the confirmation message within a few minutes of signing up, please check your spam/junk e-mail folder.
-      </p>
-
-      <div class="govuk-inset-text">
-        <%= link_to "Connect to GovWifi with your government or public sector email address", "/about-govwifi/connect-to-govwifi", class: "bold" %>
       </div>
+      
+       <p>Once this has been done, you will receive an email containing your GovWifi username and password.</p> 
+       <p>If you do not receive the username and password confirmation e-mail within a few minutes of signing up, please check your spam/junk e-mail folder.</p>
+
+     <div>
+     <h2>2. Connect your device to GovWifi</h2>
+        <p>When you are in a <%= link_to "organisation that offers GovWifi",
+        "/about-govwifi/organisations-using-govwifi" %>, follow the steps below to connect your device:</p>
+        <ul class="list list-bullet">
+          <li>go to your device wifi settings and select GovWifi.</li>
+		  <li>enter the GovWifi username and password you received by email.</li>
+		  <li>your password is case sensitive. It’s 3 words without spaces. The first letter of each word is capitalised.</li>
+		  <li>you can use the same username and password on all the devices you connect to GovWifi.</li> 
+        </ul>
+      </div>
+      
+      <p>
+        Please review our <a href="https://www.wifi.service.gov.uk/support">support guides</a> for device specific instructions.
+      </p>
+      
     </div>
   </div>
 </div>


### PR DESCRIPTION
Need to make clear distinction between the two steps involved to signup for GovWifi as a visitor