### PR TITLE
Hotfix/copy s3 files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM governmentpaas/cf-cli
+FROM governmentpaas/cf-cli@sha256:72b16cd35a3dff6ddf66d57af28ffba5dee9579372c6e84a733364df550a92a3
 
 WORKDIR /usr/src/app
 

--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -95,7 +95,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: latest
+            version: {digest: "sha256:ffde094aad190bd81049840631154794e9bfc353a281791ebcd3082f70e469fe"}
           inputs:
             - name: govwifi-product-page-pr
               path: repo
@@ -137,7 +137,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: latest
+            version: {digest: "sha256:ffde094aad190bd81049840631154794e9bfc353a281791ebcd3082f70e469fe"}
           inputs:
             - name: govwifi-product-page
               path: repo

--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -37,8 +37,6 @@ resources:
     type: s3
     source:
       bucket: govwifi-production-product-page-data
-      access_key_id: "((deploy-access-key-id))"
-      secret_access_key: "((deploy-secret-access-key))"
       versioned_file: organisations.yml
       region_name: eu-west-2
 
@@ -46,8 +44,6 @@ resources:
     type: s3
     source:
       bucket: govwifi-production-product-page-data
-      access_key_id: "((deploy-access-key-id))"
-      secret_access_key: "((deploy-secret-access-key))"
       versioned_file: domains.yml
       region_name: eu-west-2
 
@@ -98,8 +94,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: governmentpaas/cf-cli
+              tag: latest
           inputs:
             - name: govwifi-product-page-pr
               path: repo
@@ -110,9 +106,7 @@ jobs:
             - -eu
             - -c
             - |
-              curl -sL https://deb.nodesource.com/setup_12.x | bash -
-              apt-get update
-              apt-get install -y nodejs
+              apk --update add g++ musl-dev make nodejs nodejs-npm
               npm install --unsafe-perm
               bundle install --without development
               bundle exec middleman build
@@ -142,11 +136,13 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: governmentpaas/cf-cli
+              tag: latest
           inputs:
             - name: govwifi-product-page
               path: repo
+            - name: whitelisted-emails
+            - name: organisations-list
           outputs:
             - name: bundled
           run:
@@ -156,9 +152,7 @@ jobs:
             - -eu
             - -c
             - |
-              curl -sL https://deb.nodesource.com/setup_12.x | bash -
-              apt-get update
-              apt-get install -y nodejs
+              apk --update add g++ musl-dev make nodejs nodejs-npm
               npm install --unsafe-perm
               bundle install --without development
               cp ../whitelisted-emails/domains.yml data/domains.yml

--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -37,6 +37,8 @@ resources:
     type: s3
     source:
       bucket: govwifi-production-product-page-data
+      access_key_id: "((deploy-access-key-id))"
+      secret_access_key: "((deploy-secret-access-key))"
       versioned_file: organisations.yml
       region_name: eu-west-2
 
@@ -44,6 +46,8 @@ resources:
     type: s3
     source:
       bucket: govwifi-production-product-page-data
+      access_key_id: "((deploy-access-key-id))"
+      secret_access_key: "((deploy-secret-access-key))"
       versioned_file: domains.yml
       region_name: eu-west-2
 
@@ -83,10 +87,6 @@ jobs:
       - get: govwifi-product-page-pr
         trigger: true
         version: every
-      - get: organisations-list
-        trigger: true
-      - get: whitelisted-emails
-        trigger: true
       - put: govwifi-product-page-pr
         params:
           status: pending
@@ -161,6 +161,8 @@ jobs:
               apt-get install -y nodejs
               npm install --unsafe-perm
               bundle install --without development
+              cp ../whitelisted-emails/domains.yml data/domains.yml
+              cp ../organisations-list/organisations.yml data/organisations.yml
               bundle exec middleman build
               cp -r . ../bundled/
       - put: deploy-to-paas


### PR DESCRIPTION
Hotfix: copy S3 files with bundled before deployment

The pipeline was retrieving the S3 files but was not bundling
them before deployment.
Because there are default files in place, the build does not fail
and the test files are deployed instead.

The reason the files were being copied before was because this
line on the Dockerfile was masking the bug:
https://github.com/alphagov/govwifi-product-page/blob/b51e52575f7b6606a8ce048242b94d8470d673dd/Dockerfile#L11

This is similar to the issue we saw before on 49bc9c49b434f995a6123771a0845776db340628

- gdsre/aws-ruby causes the deployment to fail with a US-ASCII error.
This does not happen with governmentpaas/cf-cli which is used by
Dockerfile, suggesting it's built with a correct locale.

- remove AWS credentials (not needed)

- add missing inputs to build step

**UAT:** temporarily deployed here, you can check it passes https://cd.gds-reliability.engineering/teams/govwifi/pipelines/product-page-deploy-test