### PR TITLE
Add service status link to footer

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -78,7 +78,7 @@
                 <%= link_to 'Terms and conditions', '/terms-and-conditions' %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Performance', 'https://www.gov.uk/performance/govwifi' %>
+                <%= link_to 'Service performance', 'https://www.gov.uk/performance/govwifi' %>
               </li>
             </ul>
           </div>
@@ -92,7 +92,7 @@
                 <%= link_to 'Organisations using GovWifi', '/about-govwifi/organisations-using-govwifi' %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Support', '/support' %>
+                <%= link_to 'Service status', 'https://status.wifi.service.gov.uk/', class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Provide users with a link to service status page to check if GovWifi is operating normally