### PR TITLE
Vgphb19 patch 29

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -78,7 +78,7 @@
                 <%= link_to 'Terms and conditions', '/terms-and-conditions' %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Performance', 'https://www.gov.uk/performance/govwifi' %>
+                <%= link_to 'Service performance', 'https://www.gov.uk/performance/govwifi' %>
               </li>
             </ul>
           </div>
@@ -92,7 +92,7 @@
                 <%= link_to 'Organisations using GovWifi', '/about-govwifi/organisations-using-govwifi' %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Support', '/support' %>
+                <%= link_to 'Service status', 'https://status.wifi.service.gov.uk/', class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Rebuild of https://github.com/alphagov/govwifi-product-page/pull/180 because of CI restrictions on forked repo builds.