### PR TITLE
Provide end users with link to our service status

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -25,7 +25,13 @@ description: Help and support connecting to GovWifi
       <p>
         If you need a GovWifi username or password reminder, please send a blank email from the email address you registered with to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk" %>.
       </p>
-       
+      <h4 class="heading-s">Check GovWifi service status</h4>
+      <p>
+        You can check the <%= link_to "status of our central authentication service", "https://status.wifi.service.gov.uk", class: "govuk-link" %>.
+      </p>
+      <p>
+        If our service is operating normally and you are still having difficulty connecting to GovWifi, please contact the IT support desk in your building.
+      </p> 
       <h2 class="heading-medium">Network administrator support</h2>
       <p>
         We provide network administrator guidance on how to install and manage GovWifi in your organisation in our <%= link_to "technical documentation", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.


### PR DESCRIPTION
We need to provide end-users seeking support a way to check the status of the GovWifi authentication service so that they can determine if there is a service or local problem affecting their use of GovWifi