### PR TITLE
Explain single user login proposition better

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -12,7 +12,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
           <img src="/images/Product-illustration.png" alt="" role="presentation" width="100%">
         </div>
         <p class="hero__description">
-          GovWifi is a wifi authentication service allowing staff and visitors to use a single user login to connect to guest wifi across the public sector.
+          GovWifi is a wifi authentication service allowing staff and visitors to use the same username and password to connect to guest wifi across the public sector.
         </p>
         <a href="https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/" role="button" class="hero-button" data-click-events="" data-click-category="Hero" data-click-action="Button clicked">
                     Connect to GovWifi


### PR DESCRIPTION
Our proposition needs to be clearer on the homepage so users can instantly understand the offering, which is they can use same username and password across the public sector to access wifi