### PR TITLE
Update header to be clearer about connect devices

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -51,7 +51,7 @@
 
           <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
             <ul>
-              <li><%= link_to 'Connect to GovWifi', '/about-govwifi/connect-to-govwifi' %></li>
+              <li><%= link_to 'Connect a device', '/about-govwifi/connect-to-govwifi' %></li>
               <li><%= link_to 'Offer GovWifi', 'https://docs.wifi.service.gov.uk' %></li>
               <li><%= link_to 'Support', '/support' %></li>
               <li><%= link_to 'Admin', 'https://admin.wifi.service.gov.uk/' %></li>


### PR DESCRIPTION
Currently the instructions for connecting devices to GovWifi is labelled as 'Connect to GovWifi' on the header. We've had feedback that this phrasing is ambiguous vs 'Offer GovWifi' causing prospective network admins selecting Connect to GovWifi

Therefore make the link more explicit as 'Connect a device' to enable users to distinguish with offering govwifi as a service and connecting as an end user

Rebuild of https://github.com/alphagov/govwifi-product-page/pull/194