### PR TITLE
Tell admins how to raise support tickets when not signed in

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -36,6 +36,10 @@ description: Help and support connecting to GovWifi
       <p>
         We provide network administrator guidance on how to install and manage GovWifi in your organisation in our <%= link_to "technical documentation", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.
       </p>
+      <p>
+        <%= link_to 'Sign in as a network administrator', 'https://admin.wifi.service.gov.uk/' %>
+        to send a support request.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If we’re worried that admin users will get stuck trying to find where to go for support when not signed in, now that we’ve removed the link to the support form from the sign in page<sup>1</sup>, we should change this.

I’ve tried to word the link in such a way that end-users won’t think this is the place for them to get support.

1. https://github.com/alphagov/govwifi-admin/pull/824