### PR TITLE
Copy only required built files and manifest.yml to deploy step

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -144,7 +144,7 @@ jobs:
             - name: whitelisted-emails
             - name: organisations-list
           outputs:
-            - name: bundled
+            - name: build
           run:
             path: sh
             dir: repo
@@ -158,9 +158,10 @@ jobs:
               cp ../whitelisted-emails/domains.yml data/domains.yml
               cp ../organisations-list/organisations.yml data/organisations.yml
               bundle exec middleman build
-              cp -r . ../bundled/
+              cp -r build/* ../build
+              cp manifest.yml ../build
       - put: deploy-to-paas
         params:
-          manifest: bundled/manifest.yml
+          manifest: build/manifest.yml
           show_app_log: true
-          path: bundled
+          path: build


### PR DESCRIPTION
This change copies only necessary files to the deploy-to-pass step.

Path is removed from cf manifest.yml as this caused files to fail to be served by the static buildpack.

Offending commit to CF resource: https://github.com/concourse/cf-resource/commit/e07c4c5a154cfb6a2950d84c07b53a70c7513e7d