### PR TITLE
gem: move to libsassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'middleman', '>= 4.0.0'
 gem 'middleman-livereload'
 gem "middleman-sprockets"
+gem 'sprockets', '4.0.0beta10'
 gem 'sass'
+gem 'sassc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       ffi (~> 1.9)
       rake
     servolux (0.13.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0.beta10)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.1)
@@ -122,6 +122,8 @@ DEPENDENCIES
   middleman-livereload
   middleman-sprockets
   sass
+  sassc
+  sprockets (= 4.0.0beta10)
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -12,8 +12,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="<%= current_page.data.description %>">
 
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
-    <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag :manifest, media: 'screen' %><!--<![endif]-->
+    <!--[if lte IE 8]><%= stylesheet_link_tag 'manifest-old-ie', media: 'screen' %><![endif]-->
     <%= stylesheet_link_tag :print, media: 'print' %>
 
     <%= javascript_include_tag :application %>

--- a/source/stylesheets/manifest-old-ie.css
+++ b/source/stylesheets/manifest-old-ie.css
@@ -1,0 +1,5 @@
+$is-ie: true;
+$ie-version: 8;
+
+//= require screen
+//= link_tree "../../node_modules/govuk-frontend/govuk/assets"

--- a/source/stylesheets/manifest.css
+++ b/source/stylesheets/manifest.css
@@ -1,0 +1,2 @@
+//= require screen
+//= link_tree "../../node_modules/govuk-frontend/govuk/assets"

--- a/source/stylesheets/manifest.css.scss
+++ b/source/stylesheets/manifest.css.scss
@@ -1,1 +1,0 @@
-//= link_tree ../../node_modules/govuk-frontend/govuk/assets

--- a/source/stylesheets/screen-old-ie.css.scss
+++ b/source/stylesheets/screen-old-ie.css.scss
@@ -1,4 +1,0 @@
-$is-ie: true;
-$ie-version: 8;
-
-@import "core";


### PR DESCRIPTION
The `sass` ruby gem is deprecated and `libsassc` (gem name: `sassc`)
is a much-faster, drop-in replacement.

Unfortunately `middleman-sprockets` isn't always happy with the new
gem<sup>[1]</sup> so include the old one as well in the bundle.

As per the code changes, point towards a standard and IE-specific
manifests, which in turn include the GOV.UK Frontend assets with the
correct ie-specific variables set in the latter case.

(re)compile-time greatly reduced.

[1]: https://github.com/middleman/middleman-sprockets/issues/132