### PR TITLE
Fix accessibility issues found by Power Mapper

### DIFF
--- a/source/about-govwifi/organisations-using-govwifi.html.erb
+++ b/source/about-govwifi/organisations-using-govwifi.html.erb
@@ -50,4 +50,3 @@ description: Find all the public sector organisations where GovWifi is available
 </main>
 
 <%= partial 'shared/dynamic_search_bar' %>
-<%= partial 'shared/dynamic_search_bar_noscript' %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -10,7 +10,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
           <div class="hero__body">
             <h1 class="hero__title govuk-heading-xl">Public sector guest wifi</h1>
             <div class="hero__inline-image">
-              <img src="/images/Product-illustration.png" alt="" role="presentation" width="100%">
+              <img src="/images/Product-illustration.png" role="presentation" width="100%">
             </div>
             <p class="hero__description govuk-body">
               GovWifi is a wifi authentication service allowing staff and visitors to use a single username and password to connect to guest wifi across the public sector.
@@ -25,7 +25,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
         </div>
         <div class="govuk-grid-column-one-third">
           <div class="hero__aside-image main-image">
-            <img src="/images/Product-illustration.png" alt="govwifi-image" role="presentation" width="100%">
+            <img src="/images/Product-illustration.png" role="presentation" width="100%">
           </div>
         </div>
       </div>

--- a/source/shared/_dynamic_search_bar_noscript.html.erb
+++ b/source/shared/_dynamic_search_bar_noscript.html.erb
@@ -1,5 +1,0 @@
-<noscript>
-  <style>
-    #search-table { display:none; }
-  </style>
-</noscript>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -28,6 +28,7 @@ body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
   font-family: "GDS Transport", Arial, sans-serif;
+  background: govuk-colour("white");
 }
 
 // scss-lint:disable IdSelector

--- a/source/stylesheets/modules/_striped-table.scss
+++ b/source/stylesheets/modules/_striped-table.scss
@@ -1,3 +1,5 @@
+.no-js #search-table { display: none; }
+
 .table-header {
   background-color: $govuk-brand-colour;
   color: white;

--- a/source/support/check-organisation-email-address.html.erb
+++ b/source/support/check-organisation-email-address.html.erb
@@ -55,4 +55,3 @@ description: Check your government or public sector email address to sign up to 
 </main>
 
 <%= partial 'shared/dynamic_search_bar' %>
-<%= partial 'shared/dynamic_search_bar_noscript' %>


### PR DESCRIPTION
# What

Power Mapper reported a few accessibility issues which this PR fixes.

# Why

We are trying to improve accessibility of our products.

# How

The PR fixes the following:

* In case custom colours (e.g. black) have been specified in the user-agent by the user, some of the text was not legible since font colour of most if not all text as set in the CSS. This PR fixes this by also providing the default background colour in CSS, which provides sufficient contrast against the font colour. See [here][F24] for more info on the W3C guidelines governing this.

* In case of JS is disabled, custom styling was being injected using a `noscript` tag. This isn't allowed outside of the `head` element. This PR fixes this by specifying this styling in a CSS file, targeted using the `no-js` selector.

* Alternative text was being provided for presentation-only images. This isn't allowed, and so has been removed. See [here][F39] for more info on the W3C guidelines on this.

[F24]: https://www.w3.org/TR/WCAG20-TECHS/F24.html
[F39]: https://www.w3.org/TR/WCAG20-TECHS/F39.html