### PR TITLE
Only cache for 10 minutes instead of 24h

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+location_include: cache-expiry.conf

--- a/nginx/conf/cache-expiry.conf
+++ b/nginx/conf/cache-expiry.conf
@@ -1,0 +1,1 @@
+add_header Cache-Control "max-age:600";


### PR DESCRIPTION
CDN apparently caches for 24h, but we want to deliver our new content faster, so we're limiting to 10 minutes.