### PR TITLE
feature: add a page to describe GovWifi server certificate update

### DIFF
--- a/source/shared/support/_sidebar.html.erb
+++ b/source/shared/support/_sidebar.html.erb
@@ -1,5 +1,6 @@
 <% menu_items = [
   { title: "GovWifi support", link: "/support/" },
+  { title: "Update the GovWifi server certificate", link: "/support/update-govwifi-server-certificate/" },
   { title: "Check your organisation email address", link: "/support/check-organisation-email-address/" },
   { title: "Connect to GovWifi as a visitor", link: "/support/visitor-access-to-govwifi/" },
   { title: "Connect an Android device", link: "/support/connect-to-govwifi-using-an-android-device/" },

--- a/source/support/update-govwifi-server-certificate.html.erb
+++ b/source/support/update-govwifi-server-certificate.html.erb
@@ -1,0 +1,40 @@
+---
+title: Update the GovWifi server certificate - GovWifi
+description: Updating the GovWifi server certificate to keep using the service
+---
+<div class="govuk-width-container">
+  <%= partial "shared/support/breadcrumbs", locals: { page: "Update the GovWifi server certificate" } %>
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= partial 'shared/support/sidebar' %>
+      </div>
+      <main class="govuk-grid-column-two-thirds" role="main" id="main">
+        <h1 class="govuk-heading-l">Update the GovWifi server certificate</h1>
+        <p class="govuk-body">Every 2 years, GovWifi has to renew its server certificate to keep GovWifi as secure as possible.</p>
+        <p class="govuk-body">From the 11 November 2019, users on iOS and MacOS devices may receive a pop up message on their device asking them to accept the new certificate. Users will have to accept to continue using the GovWifi service. Android users should have the new certificate automatically accepted.</p>
+
+        <h2 class="govuk-heading-m">What you need to do to continue using GovWifi</h2>
+
+        <p class="govuk-body">To continue using GovWifi, you must switch to the new certificate when the message prompts you on your device. You must do this for all of your devices which use GovWifi.</p>
+
+        <h3 class="govuk-heading-s">Switching to the new certificate on your mobile</h3>
+        <ol class="govuk-list govuk-list--number">
+          <li>If you receive the GovWifi pop up message on your mobile device, select Accept.</li>
+          <li>Your device will automatically switch to the new certificate and reconnect to GovWifi.</li>
+          <li>You can continue using GovWifi as normal.</li>
+        </ol>
+
+        <h3 class="govuk-heading-s">Switching to the new certificate on your desktop or laptop</h3>
+        <ol class="govuk-list govuk-list--number">
+          <li>If you receive the ‘Authenticating to network “GovWifi”’ pop up message on your desktop or laptop device, select Continue.</li>
+          <li>Your device will automatically switch to the new certificate and reconnect to GovWifi.</li>
+          <li>You can continue using GovWifi as normal.</li>
+        </ol>
+
+        <h2 class="govuk-heading-m">If you need further support</h2>
+        <p class="govuk-body">If you have any questions or need more help, contact your IT support desk.</p>
+      </main>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Description
We're updating our server certificate, iOS and macOS users will have to re-accept the new one. This PR adds a support page to that effect.

This has been reviewed by Steve W. ✅ 