### PR TITLE
fix: mention Windows users in the certificate upgrade help page

### DIFF
--- a/source/support/update-govwifi-server-certificate.html.erb
+++ b/source/support/update-govwifi-server-certificate.html.erb
@@ -12,7 +12,7 @@ description: Updating the GovWifi server certificate to keep using the service
       <main class="govuk-grid-column-two-thirds" role="main" id="main">
         <h1 class="govuk-heading-l">Update the GovWifi server certificate</h1>
         <p class="govuk-body">Every 2 years, GovWifi has to renew its server certificate to keep GovWifi as secure as possible.</p>
-        <p class="govuk-body">From the 11 November 2019, users on iOS and MacOS devices may receive a pop up message on their device asking them to accept the new certificate. Users will have to accept to continue using the GovWifi service. Android users should have the new certificate automatically accepted.</p>
+        <p class="govuk-body">From the 11 November 2019, users on iOS, MacOS and Windows devices may receive a pop up message on their device asking them to accept the new certificate. Users will have to accept to continue using the GovWifi service. Android users should have the new certificate automatically accepted.</p>
 
         <h2 class="govuk-heading-m">What you need to do to continue using GovWifi</h2>
 


### PR DESCRIPTION
RE has notified us that they will also be affected by the server
certificate change, so make sure they're included in the support page
for that effect.