### PR TITLE
bau: add section to Support for users having issues connecting

### DIFF
--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -24,6 +24,12 @@ description: Help and support connecting to GovWifi
         <p class="govuk-body">
           If you need a GovWifi username or password reminder, please send a blank email from the email address you registered with to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk", class: "govuk-link" %>.
         </p>
+        <h4 class="govuk-heading-s">Account no longer active or failing to connect</h4>
+        <p class="govuk-body">
+          Credentials are deleted if you haven't used GovWifi for 12 months. To re-activate your account, please
+          send a blank email from the email address you registered with
+          to <%= link_to "signup@wifi.service.gov.uk", "mailto: signup@wifi.service.gov.uk", class: "govuk-link" %>.
+        </p>
         <h4 class="govuk-heading-s">Check GovWifi service status</h4>
         <p class="govuk-body">
           You can check the <%= link_to "status of our central authentication service", "https://status.wifi.service.gov.uk", class: "govuk-link" %>.


### PR DESCRIPTION
- Note that we don't say anywhere in the product page about accounts being deactivated and deleted after a period of time: there is only a small paragraph on the privacy note about us deleting accounts after 12 months
- The MOU says credentials are deemed inactive after 90 days, but I haven't found anywhere in the code or data where we enforce that.