### PR TITLE
feat: allow users to manage their cookie preferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
       "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
     },
     "govwifi-shared-frontend": {
-      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.2/govwifi-shared-frontend-0.6.2.tgz",
-      "integrity": "sha512-4+GYwVh2AMwqF2W708CU9W7eqDa64My3Ob2DU48o3VqPNa6h/DB4wVWP+q9qCaRq2ByZGYlQL5Yg+yHJ6iYt7g==",
+      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.4/govwifi-shared-frontend-0.6.4.tgz",
+      "integrity": "sha512-KQCZGCjX4nANCvdI3jL2dvx82l3d+fb1WXiwSUxyTLaCmD1qvppzbgiKUwM4WZDA7VG+gFstPyO3KClejwbYQA==",
       "requires": {
         "js-cookie": "^2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^3.6.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.2/govwifi-shared-frontend-0.6.2.tgz"
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.4/govwifi-shared-frontend-0.6.4.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -14,7 +14,7 @@ title: Cookies
     </ol>
   </nav>
   <main class="govuk-main-wrapper" role="main" id="main">
-    <div class="govuk-grid-row" id="cookie-preferences-amended" style="display: none">
+    <div class="govuk-grid-row" id="cookie-preferences-amended">
       <div class="govuk-grid-column-two-thirds">
         <div class="container">
           <h2 class="govuk-heading-m">

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -14,6 +14,16 @@ title: Cookies
     </ol>
   </nav>
   <main class="govuk-main-wrapper" role="main" id="main">
+    <div class="govuk-grid-row" id="cookie-preferences-amended" style="display: none">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="container">
+          <h2 class="govuk-heading-m">
+            Your cookie settings were saved.
+          </h2>
+        </div>
+      </div>
+    </div>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Cookies</h1>
@@ -97,6 +107,31 @@ title: Cookies
             </tr>
           </tbody>
         </table>
+
+        <form id="cookie-settings">
+          <div class="govuk-form-group govuk-!-margin-top-6">
+            <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Do you want to accept analytics cookies?
+              </legend>
+              <div class="govuk-radios govuk-radios--inline">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="cookies-tracking-on" name="tracking" type="radio" value="on">
+                  <label class="govuk-label govuk-radios__label" for="cookies-tracking-on">
+                    Yes
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="cookies-tracking-off" name="tracking" type="radio" value="off">
+                  <label class="govuk-label govuk-radios__label" for="cookies-tracking-off">
+                    No
+                  </label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <button class="govuk-button" type="submit">Save cookie settings</button>
+        </form>
       </div>
     </div>
   </main>

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,5 +1,40 @@
+function submitCookiePreferences(e) {
+  e.preventDefault();
+
+  const data = new FormData(this);
+
+  for (let category of data.keys()) {
+    GovWifi.cookies.setCategoryAllowed(category, data.get(category) === "on");
+  }
+
+  document.getElementById("cookie-preferences-amended").style.display = "block";
+
+  window.scrollTo(0, 0);
+}
+
+function setCategoryInput(category) {
+  const isAllowed = GovWifi.cookies.isCategoryAllowed(category);
+  const selector = isAllowed ? "on" : "off";
+
+  const input = document.getElementById(`cookies-${category}-${selector}`);
+
+  input.checked = true;
+}
+
+function setupCookiePreferencesPage() {
+  const form = document.getElementById("cookie-settings");
+
+  if (!form) return;
+
+  setCategoryInput("tracking");
+
+  form.addEventListener("submit", submitCookiePreferences);
+}
+
 document.addEventListener("DOMContentLoaded", function() {
   GOVUKFrontend.initAll();
 
   GovWifi.cookies.checkCookiePolicy("cookie-banner");
+
+  setupCookiePreferencesPage();
 });

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -12,7 +12,7 @@ function submitCookiePreferences(e) {
   window.scrollTo(0, 0);
 }
 
-function setCategoryInput(category) {
+function setupCookiePreferencesOptions(category) {
   const isAllowed = GovWifi.cookies.isCategoryAllowed(category);
   const selector = isAllowed ? "on" : "off";
 
@@ -26,7 +26,7 @@ function setupCookiePreferencesPage() {
 
   if (!form) return;
 
-  setCategoryInput("tracking");
+  setupCookiePreferencesOptions("tracking");
 
   form.addEventListener("submit", submitCookiePreferences);
 }

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -9,7 +9,6 @@
 @import "modules/hero-button";
 @import "modules/images";
 @import "modules/masthead";
-@import "modules/phase-banner";
 @import "modules/sticky";
 @import "modules/skip-link";
 @import "modules/striped-table";
@@ -28,17 +27,3 @@ body {
   background-color: govuk-colour('white');
 }
 // scss-lint:enable IdSelector
-
-.content-section--with-top-border {
-  padding-top: 5px;
-  border-top: 1px #dee0e2 solid;
-}
-
-.mobile_image_size {
-  height: 100%;
-  width: 165%;
-}
-
-a.long-link {
-  word-wrap: break-word;
-}

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -4,6 +4,7 @@
 
 @import "util/colours";
 
+@import "modules/cookies";
 @import "modules/hero";
 @import "modules/hero-button";
 @import "modules/images";

--- a/source/stylesheets/modules/_cookies.scss
+++ b/source/stylesheets/modules/_cookies.scss
@@ -1,0 +1,12 @@
+#cookie-preferences-amended {
+  .container {
+    border: 3px solid govuk-colour("green");
+    margin-bottom: govuk-spacing(6);
+    padding: govuk-spacing(4);
+  }
+
+  h2 {
+    color: govuk-colour('green');
+    margin-bottom: 0;
+  }
+}

--- a/source/stylesheets/modules/_cookies.scss
+++ b/source/stylesheets/modules/_cookies.scss
@@ -1,4 +1,6 @@
 #cookie-preferences-amended {
+  display: none;
+
   .container {
     border: 3px solid govuk-colour("green");
     margin-bottom: govuk-spacing(6);

--- a/source/stylesheets/modules/_phase-banner.scss
+++ b/source/stylesheets/modules/_phase-banner.scss
@@ -1,3 +1,0 @@
-.app-phase-banner {
-  border-bottom: 0;
-}

--- a/source/support/connect-to-govwifi-using-a-windows-device.html.erb
+++ b/source/support/connect-to-govwifi-using-a-windows-device.html.erb
@@ -168,7 +168,7 @@ description: Follow these instructions to connect your Windows device to GovWifi
         <ol class="govuk-list govuk-list--number">
           <li>
             <p class="govuk-body">In your web browser, navigate
-              to: <%= link_to "https://www.digicert.com/digicert-root-certificates.htm", "https://www.digicert.com/digicert-root-certificates.htm", class: "govuk-link long-link" %>
+              to: <%= link_to "https://www.digicert.com/digicert-root-certificates.htm", "https://www.digicert.com/digicert-root-certificates.htm", class: "govuk-link" %>
               and select Download under 'DigiCert Global Root CA'. Save the file to the C: drive</p>
           </li>
           <li>


### PR DESCRIPTION
# Description
At the moment we only ask people using our websites whether they're OK with cookies or not. This preference needs to be amendable at a later date, so rework the `/cookies` page to allow managing it.

# Screenshot
![Peek 2020-03-27 15-04](https://user-images.githubusercontent.com/107635/77769921-68fd4980-703c-11ea-8436-bf428bf20dfd.gif)

# Testing
- Please clone locally and have a go at it. Don't forget to run `npm install`;
- Check that the `cookie_preferences` cookie reflects the changes.