### PR TITLE
Add live service routes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,6 @@ applications:
   path: ./build
   buildpacks:
    - staticfile_buildpack
+  routes:
+   - route: govwifi-product-page.cloudapps.digital
+   - route: www.wifi.service.gov.uk


### PR DESCRIPTION
When the deploy happens, it uses the zero downtime plugin, which needs all routes to be in the manifest, because it creates a new app