### PR TITLE
remove race condition in concourse pipeline

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -124,6 +124,7 @@ jobs:
     serial: true
     plan:
       - get: govwifi-product-page
+        passed: [self-update]
         trigger: true
       - get: organisations-list
         trigger: true


### PR DESCRIPTION
This is a solution recommended by Toby (PaaS team) to remove race condition and hereby, ensuring `self-update` job finishes before `deploy` job starts.