### PR TITLE
Remove page titles line from statement

### DIFF
--- a/source/_statement.html.md
+++ b/source/_statement.html.md
@@ -1,76 +1,71 @@
 # Accessibility statement for GovWifi
-This website is run by the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+This service is run by the Government Digital Service (GDS). We want as many people as possible to be able to use it. For example, that means you should be able to:
 
 * change colours, contrast levels and fonts
 * zoom in up to 300% without the text spilling off the screen
-* navigate most of the website using just a keyboard
-* navigate most of the website using speech recognition software
-* listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+* navigate most of the service using just a keyboard
+* navigate most of the service using speech recognition software
+* listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
 
-We’ve also made the website text as simple as possible to understand.
+We’ve also made the service text as simple as possible to understand.
 
 [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
 
-## What to do if you cannot access parts of this website
-If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, contact [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk).
+## What to do if you cannot access parts of this service
+If you need information on this service in a different format like accessible PDF, large print, easy read, audio recording or braille, contact [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk)
 
 We’ll consider your request and get back to you within 2 working days.
 
-## Reporting accessibility problems with this website
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk).
+## Reporting accessibility problems with this service
+We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk)
 
 ## Enforcement procedure
 The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
-# Technical information about this website’s accessibility
-GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+# Technical information about this service’s accessibility
+We're committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+This service is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, because of the non-compliances listed below.
 
 ## Non accessible content
 
-The content listed below is non-accessible for the following reasons.
+Some content on our [status page](https://status.wifi.service.gov.uk/) is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard. The non-compliances are: 
 
-### Non compliance with the accessibility regulations
+* an incorrect heading hierarchy, which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
 
-* On our administrative portal, not all of our pages are identified with a unique title.
+* missing level 1 headings, so users may not be able to accurately determine the structure of content on the page
 
-* Our [status incident page](https://status.wifi.service.gov.uk/) has an incorrect heading hierarchy which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+* a missing main heading and an incorrect heading hierarchy on the status home page, which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
 
-* Our status page is missing level 1 headings (users may not be able to accurately determine the structure of content on the page).
+* the 'subscribe to updates' link does not contain programmatically discernible link text, which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
 
-* Our status page is missing the main heading and the status home page has an incorrect heading hierarchy. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+* the 'subscribe to updates' form fields do not contain an explicit label, which fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships)
 
-* Our status page 'subscribe to updates' link does not contain programmatically discernible link text. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+* the 'subscribe to updates' forms do not make it clear that they are expandable or collapsible, which fails WCAG 2.1A 4.1.2 success criterion (Name, Role, Value)
 
-* Our status page 'subscribe to updates' form fields do not contain an explicit label. This fails WCAG 2.1A 1.3.1 success criterion (Info and Relationships).
+* the 'subscribe to updates' forms contain some text that does not meet the minimum colour contrast requirements, which fails WCAG 2.1AA 1.4.3 success criterion (Contrast (Minimum))
 
-* Our status page 'subscribe to updates' forms do not indicate to users that they are expandable or collapsible. This fails WCAG 2.1A 4.1.2 success criterion (Name, Role, Value).
+* the 'subscribe to updates' form close link ('x') is not descriptive enough for some users to work out its function or purpose, which fails WCAG 2.1A 2.4.4 success criterion (Link Purpose (In Context))
 
-* Our status page 'subscribe to updates' forms contain some text that does not meet the minimum colour contrast requirements. This fails WCAG 2.1AA 1.4.3 success criterion (Contrast (Minimum)).
+* the 'subscribe to updates' forms do not inform screen reader users of the error message that appears after incorrect data has been submitted, which fails WCAG 2.1AA 4.1.3 success criterion (Status Messages)
 
-* Our status page 'subscribe to updates' form close link (x) is not descriptive enough for some users to determine its function or purpose. This fails WCAG 2.1A 2.4.4 success criterion (Link Purpose (In Context)).
+We plan to have these issues addressed by the current supplier, or move to an alternative supplier in 2021.
 
-* Our status page 'subscribe to updates' forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available. This fails WCAG 2.1AA 4.1.3 success criterion (Status Messages).
+## How we tested this service
+This service was last tested in September 2020. The test was carried out by GDS developers using a combination of automated and manual tests.
 
-We plan to have the status page issues listed above addressed by the current supplier or move to an alternative supplier in 2021.
+We tested the:
 
-## How we tested this website
-This website was last tested in September 2020. The test was carried out by GDS developers using a combination of automated and manual tests.
+* [GovWifi information pages](https://www.wifi.service.gov.uk/), which give instructions for using GovWifi 
+* [GovWifi admin platform](https://admin.wifi.service.gov.uk/users/sign_in), where users manage their organisation's use of GovWifi 
+* [status page](https://status.wifi.service.gov.uk/), where users can see GovWifi incidents
 
-We tested:
-
-* our main website platform, available at <https://www.wifi.service.gov.uk/>
-* our administrative platform, available at <https://admin.wifi.service.gov.uk/users/sign_in>
-* our documentation pages, available at <https://docs.wifi.service.gov.uk>
+We also have a separate [accessibility statement for the GovWifi technical documentation pages](https://docs.wifi.service.gov.uk/accessibility/#accessibility-statement-for-govwifi-technical-documentation).
 
 When testing GovWifi, we:
 
-* used Lighthouse to audit each page for accessibility issues
+* used 'Lighthouse' to audit each page for accessibility issues
 * tested a sample of GovWifi product and documentation pages
-* tested successful and unsuccessful end user journeys
+* tested successful and unsuccessful user journeys
 
-## What we’re doing to improve accessibility
-We have recorded these issues in our backlog and will be handling them as part of our normal workflow. The website will be fully accessible by the end of the year.
-
-This statement was prepared on 11 September 2019. It was last updated on 22 September 2020.
+This statement was prepared on 11 September 2019. It was last updated on 30 October 2020.


### PR DESCRIPTION
Removed the line saying we weren't compliant because of the page titles issue as we've now done that work. 

Also made a few other changes for style, readability and accuracy.