### PR TITLE
Fix typo in cookie message

### DIFF
--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -102,7 +102,7 @@ title: Cookies
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><code>_gid</code></td>
-              <td class="govuk-table__cell">his helps us count how many people visit GovWifi by tracking if you’ve visited before</td>
+              <td class="govuk-table__cell">This helps us count how many people visit GovWifi by tracking if you’ve visited before</td>
               <td class="govuk-table__cell">3 days</td>
             </tr>
           </tbody>


### PR DESCRIPTION
Add a missing "T" to make it a sensible sentence.