### PR TITLE
Update privacy notice

### DIFF
--- a/source/privacy-notice.html.erb
+++ b/source/privacy-notice.html.erb
@@ -11,37 +11,47 @@ description: Find details about the GovWifi privacy policy and how we collect an
       </div>
       <main class="govuk-grid-column-two-thirds" role="main" id="main">
         <h1 class="govuk-heading-l">GovWifi privacy notice</h1>
+        <p class="govuk-body">
+          Last updated: 30 April 2021
+        </p>
         <h2 class="govuk-heading-m" id="who-we-are">Who we are</h2>
         <p class="govuk-body">
-          GovWifi is a secure wifi service, developed by GDS. It provides wifi access in government buildings.
+          GovWifi is a secure wifi service. It provides wifi access in government buildings.
+        </p>
+        <p class="govuk-body">
+          GovWifi is provided by the Cabinet Office.
+        </p>
+        <p class="govuk-body">
+          The Cabinet Office is the data controller for GovWifi.
+          The Cabinet Office determines how and why personal data is processed.
+          <%= link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053", class: "govuk-link" %> for more information.
         </p>
         <p class="govuk-body">
           GovWifi is currently in public beta, which means we’re still testing and improving it.
         </p>
+        <h2 class="govuk-heading-m" id="what-data-we-need">What data we collect from you</h2>
         <p class="govuk-body">
-          GovWifi is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.
-        </p>
-        <p class="govuk-body">
-          The data controller for GDS is the Cabinet Office.
-          They determine how and why personal data is processed.
-          <%= link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053", class: "govuk-link" %> for more information.
-        </p>
-        <h2 class="govuk-heading-m" id="what-data-we-need">What data we need</h2>
-        <p class="govuk-body">
-          In order that GovWifi can work effectively for you we will need the following data:
+          In order that GovWifi can work effectively for you we collect the following data:
         </p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>email address OR mobile telephone number</li>
+          <li>email address or mobile telephone number</li>
           <li>the number of authentication attempts you make</li>
           <li>activation and login dates</li>
         </ul>
         <p class="govuk-body">
           We also identify the buildings in which you access GovWifi.
         </p>
+        <h2 class="govuk-heading-m" id="legal-basis">Our legal basis for processing your data</h2>
+
         <p class="govuk-body">
-          The legal reason we process this data is to let users in government, arm’s length bodies and public sector organisations stay connected to a secure wifi service while visiting other departments and moving between buildings.
+          The legal basis for processing your personal data is that it’s necessary to perform a task in the public interest.
         </p>
-        <h2 class="govuk-heading-m" id="why-we-need-it">Why we need it</h2>
+
+        <h2 class="govuk-heading-m" id="why-we-need-it">Why we need your data</h2>
+        <p class="govuk-body">
+          <p class="govuk-body">
+            We need to process personal data to let users in government, arm’s length bodies and public sector organisations stay connected to a secure wifi service while visiting other departments and moving between buildings.
+          </p>
         <p class="govuk-body">
           We need to know when you last used GovWifi so we can delete your account if it has not been used for 12 months.
         </p>
@@ -51,15 +61,17 @@ description: Find details about the GovWifi privacy policy and how we collect an
         </p>
         <p class="govuk-body">
           In accepting the terms and conditions of use you agree to the acceptable use policy of your host organisation.
+        </p>
+        <p class="govuk-body">
           That organisation may restrict access for lawful purposes.
           We are obliged to be able to identify users who do not comply with these terms and conditions so access can be restricted/terminated.
         </p>
-        <h2 class="govuk-heading-m" id="what-we-do-with-it">What we do with it</h2>
+        <h2 class="govuk-heading-m" id="what-we-do-with-it">What we do with your data</h2>
         <p class="govuk-body">
-          GDS will share this information with any host organisation from which you access the service if they request it.
+          The Cabinet Office will share this information with any host organisation from which you access the service if they request it.
         </p>
         <p class="govuk-body">
-          GDS may occasionally contact you by email or text message, using the information you’ve provided, to give you important information about the GovWifi service, including:
+          The Cabinet Office may occasionally contact you by email or text message, using the information you’ve provided, to give you important information about the GovWifi service, including:
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li>major changes to GovWifi, like restricting access to non-public sector workers</li>
@@ -85,20 +97,24 @@ description: Find details about the GovWifi privacy policy and how we collect an
           Our services are not designed for, or intentionally targeted at, children 13 years of age or younger.
           It is not our policy to intentionally collect or maintain data about anyone under the age of 13.
         </p>
-        <h2 class="govuk-heading-m" id="where-it-might-go">Where it might go</h2>
+        <h2 class="govuk-heading-m" id="where-it-might-go">Where your data is processed and stored</h2>
         <p class="govuk-body">
           We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s processed and when it’s stored.
         </p>
         <p class="govuk-body">
-          GDS will not process your personal data, or transfer it, outside of the <%= link_to "European Economic Area (EEA)", "https://www.gov.uk/eu-eea", class: "govuk-link" %>.
+          The Cabinet Office will not process your personal data, or transfer it, outside of the <%= link_to "European Economic Area (EEA)", "https://www.gov.uk/eu-eea", class: "govuk-link" %>.
         </p>
         <h2 class="govuk-heading-m " id="how-we-protect-your-data-and-keep-it-secure">How we protect your data and keep it secure</h2>
         <p class="govuk-body">
           We are committed to keeping your data secure.
-          We set up systems and processes to prevent unauthorised access or disclosure of the data we collect about you – for example, we protect your data using varying levels of encryption.
+        </p>
+        <p class="govuk-body">
+          We set up systems and processes to prevent unauthorised access or disclosure of the data we collect about you – for example, we protect your data using varying levels of encryption
+        </p>
+        <p class="govuk-body">
           We also make sure that third parties we deal with have an obligation to keep all personal data they process on our behalf secure.
         </p>
-        <h2 class="govuk-heading-m" id="what-are-your-rights">What are your rights</h2>
+        <h2 class="govuk-heading-m" id="what-are-your-rights">Your rights</h2>
         <p class="govuk-body">You have the right to request:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>information about how your personal data is processed</li>
@@ -115,9 +131,12 @@ description: Find details about the GovWifi privacy policy and how we collect an
         <h2 class="govuk-heading-m" id="changes-to-this-notice">Changes to this notice</h2>
         <p class="govuk-body">
           We may modify or amend this privacy notice at our discretion at any time.
-          When we make changes to this notice, we will amend the last modified date at the top of this page.
-          Any modification or amendment to this privacy notice will be applied to you and your data as of that revision date.
-          If these changes affect how your personal data is processed, GDS will take reasonable steps to make sure you know.
+        </p>
+        <p class="govuk-body">
+          When we make changes to this notice, we will amend the last modified date in this section. Any modification or amendment to this privacy notice will be applied to you and your data as of that revision date.
+        </p>
+        <p class="govuk-body">
+          If these changes affect how your personal data is processed, The Cabinet Office will take reasonable steps to make sure you know.
         </p>
         <h2 class="govuk-heading-m" id="how-to-contact-us">How to contact us</h2>
         <p class="govuk-body">

--- a/source/shared/_privacy_notice_sidebar.html.erb
+++ b/source/shared/_privacy_notice_sidebar.html.erb
@@ -1,12 +1,14 @@
 <% menu_items = [
   { title: "Who we are", link: "#who-we-are" },
-  { title: "What data we need", link: "#what-data-we-need" },
-  { title: "Why we need it", link: "#why-we-need-it" },
-  { title: "What we do with it", link: "#what-we-do-with-it" },
+  { title: "What data we collect from you", link: "#what-data-we-need" },
+  { title: "Our legal basis for processing your data", link: "#legal-basis" },
+  { title: "Why we need your data", link: "#why-we-need-it" },
+  { title: "What we do with your data", link: "#what-we-do-with-it" },
   { title: "How long we keep your data", link: "#how-long-we-keep-your-data" },
   { title: "Children’s privacy protection", link: "#childrens-privacy-protection" },
-  { title: "Where it might go", link: "#where-it-might-go" },
-  { title: "What are your rights", link: "#what-are-your-rights" },
+  { title: "Where your data is processed and stored", link: "#where-it-might-go" },
+  { title: "How we protect your data and keep it secure", link: "#how-we-protect-your-data-and-keep-it-secure" },
+  { title: "Your rights", link: "#what-are-your-rights" },
   { title: "Changes to this notice", link: "#changes-to-this-notice" },
   { title: "How to contact us", link: "#how-to-contact-us" }
 ] %>


### PR DESCRIPTION
Update privacy notice to: 

- Change GDS to Cabinet Office, now that GovWifi is in CDIO not GDS
- Add a 'last updated' date at the top, because the section 'Changes to this notice' says there should be one
- Improve a couple of style points 
- Update the sidebar to match all the headings 