### PR TITLE
Small changes to new certificate page

### DIFF
--- a/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
+++ b/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
@@ -10,13 +10,13 @@ description: Information about accepting the new GovWifi server certificate to k
       </div>
       <main class="govuk-grid-column-two-thirds" role="main" id="main">
         <h1 class="govuk-heading-l">Accept the new GovWifi certificate</h1>
-        <p class="govuk-body">On 5 July 2021, we’ll renew the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine GovWifi network.</p>
+        <p class="govuk-body">On 5 July 2021, we’ll renew the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine network.</p>
         <p class="govuk-body">You might need to accept the new certificate on your device to continue using GovWifi.</p>
-        <div class="govuk-inset-text">If you’re ever asked to accept a new GovWifi certificate without being told in advance by the GovWifi team, do not accept it. Report it to the IT support desk for the building you’re in.</div>
+        <div class="govuk-inset-text">If you’re ever asked to accept a new GovWifi certificate without being told about it in advance, do not accept it. Report it to the IT support desk for the building you’re in.</div>
 
         <h2 class="govuk-heading-m">What to do depends on your device</h2>
 
-        <p class="govuk-body">Your device might automatically check the new certificate and accept it. In this case, you will not need to do anything.</p>
+        <p class="govuk-body">The next time you try to connect to GovWifi, your device might automatically check the new certificate and accept it. In this case, you will not need to do anything.</p>
 
         <p class="govuk-body">Or, you may be asked to accept the new certificate.</p>
 


### PR DESCRIPTION
### What

Made it clearer that this will affect users' devices the next time they try to connect to GovWifi (not necessarily on 5 July when we do the rotation).

Also removed a couple of 'GovWifi' references as we said it a lot and it was quite repetitive.