### PR TITLE
DO NOT MERGE UNTIL MONDAY AT 8AM Add new cert details to device instructions

### DIFF
--- a/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
+++ b/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
@@ -23,13 +23,13 @@ description: Follow these instructions to connect your iPhone or iPad to GovWifi
           </li>
           <li>
             <p class="govuk-body">You'll be shown the 'certificate' and asked to trust it.</p>
-            <p class="govuk-body">Your device should show that the certificate is called <strong>wifi.service.gov.uk</strong> and is issued by <strong>GeoTrust RSA CA 2018</strong>.</p>
+            <p class="govuk-body">Your device should show that the certificate is called <strong>wifi.service.gov.uk</strong> and is issued by <strong>eoTrust TLS DV RSA Mixed SHA256 2020 CA-1</strong>.</p>
             <p class="govuk-body">It might also say ‘Not trusted’, which just means your device does not recognise the network yet.</p>
           </li>
           <li><p class="govuk-body">Select <strong>More Details</strong> and scroll down to the 'Fingerprints' section at the bottom of the page.</p></li>
           <li>
             <p class="govuk-body"><p>Check that the SHA-1 Fingerprint matches:</p>
-            <p class="govuk-body"> <strong>37 CE B5 7A 3F 38 EB 7C 66 A2 4E 90 BB 11 71 D7 BC 4D 65 1A</strong></p>
+            <p class="govuk-body"> <strong>AC 70 5D 2B 63 36 4B 3C A4 1D 13 8E 9B F7 11 E7 21 E9 E6 2A</strong></p>
             <div class="govuk-inset-text">If the certificate details are not correct, tell IT support and do not join the network.</div>
           </li>
           <li>

--- a/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
+++ b/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
@@ -23,7 +23,7 @@ description: Follow these instructions to connect your iPhone or iPad to GovWifi
           </li>
           <li>
             <p class="govuk-body">You'll be shown the 'certificate' and asked to trust it.</p>
-            <p class="govuk-body">Your device should show that the certificate is called <strong>wifi.service.gov.uk</strong> and is issued by <strong>eoTrust TLS DV RSA Mixed SHA256 2020 CA-1</strong>.</p>
+            <p class="govuk-body">Your device should show that the certificate is called <strong>wifi.service.gov.uk</strong> and is issued by <strong>GeoTrust TLS DV RSA Mixed SHA256 2020 CA-1</strong>.</p>
             <p class="govuk-body">It might also say ‘Not trusted’, which just means your device does not recognise the network yet.</p>
           </li>
           <li><p class="govuk-body">Select <strong>More Details</strong> and scroll down to the 'Fingerprints' section at the bottom of the page.</p></li>

--- a/source/connect-to-govwifi/device-mac.html.erb
+++ b/source/connect-to-govwifi/device-mac.html.erb
@@ -30,7 +30,7 @@ description: Follow these instructions to connect your Mac to GovWifi
             <%= image_tag "troubleshooting/mac-os-step-4.jpg", class: "img-fluid", alt: "Screenshot of Verify Certificate dialog on macOS" %>
           </li>
           <li>
-            <p>Select <strong>Show Certificate.</strong> Check that the certificate is called <strong>wifi.service.gov.uk</strong> and it's issued by <strong>GeoTrust RSA CA 2018</strong>.</p>
+            <p>Select <strong>Show Certificate.</strong> Check that the certificate is called <strong>wifi.service.gov.uk</strong> and it's issued by <strong>GeoTrust TLS DV RSA Mixed SHA256 2020 CA-1</strong>.</p>
           </li>
           <li>
             <p>If the certificate details are correct, select <strong>Continue</strong>. If they are not, tell IT support and do not join the network.</p>

--- a/source/connect-to-govwifi/device-windows.html.erb
+++ b/source/connect-to-govwifi/device-windows.html.erb
@@ -48,7 +48,7 @@ description: Follow these instructions to connect your Windows device to GovWifi
           </li>
           <li>
             <p class="govuk-body">Check that the <strong>Server thumbprint</strong> matches: </p>
-            <p class="govuk-body"><strong>37 CE B5 7A 3F 38 EB 7C 66 A2 4E 90 BB 11 71 D7 BC 4D 65 1A</strong></p>
+            <p class="govuk-body"><strong>AC 70 5D 2B 63 36 4B 3C A4 1D 13 8E 9B F7 11 E7 21 E9 E6 2A</strong></p>
           </li>
           <li>
             <p class="govuk-body">If it matches, select <strong>Connect</strong>. If it does not match, tell IT support and do not join the network.</p>


### PR DESCRIPTION
### What
Adding new information to the device instructions to reflect the new cert issuer and fingerprint. 

### Why
So the content is accurate when the cert is rotated on Sunday night. 