### PR TITLE
Change tenses, remove warning text

### DIFF
--- a/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
+++ b/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
@@ -10,9 +10,8 @@ description: Information about accepting the new GovWifi server certificate to k
       </div>
       <main class="govuk-grid-column-two-thirds" role="main" id="main">
         <h1 class="govuk-heading-l">Accept the new GovWifi certificate</h1>
-        <p class="govuk-body">On 5 July 2021, we’ll renew the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine network.</p>
+        <p class="govuk-body">On 5 July 2021, we renewed the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine network.</p>
         <p class="govuk-body">You might need to accept the new certificate on your device to continue using GovWifi.</p>
-        <div class="govuk-inset-text">If you’re ever asked to accept a new GovWifi certificate without being told about it in advance, do not accept it. Report it to the IT support desk for the building you’re in.</div>
 
         <h2 class="govuk-heading-m">What to do depends on your device</h2>
 
@@ -35,11 +34,10 @@ description: Information about accepting the new GovWifi server certificate to k
 
         <p class="govuk-body">If you’re on a work device, contact the organisation that gave you the device. You may not have permission to accept the new certificate.</p>
 
-        <p class="govuk-body">If you've accepted the certificate but you still cannot connect:</p>
+        <p class="govuk-body">You can also:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>forget the network and try again</li>
-          <li>restart your device and try again</li>
           <li>follow our <%= link_to "guidance on common issues", "/connect-to-govwifi/get-help-connecting", class: "govuk-link" %></li>
           <li>contact the IT support desk for the building you're in</li>
         </ul>


### PR DESCRIPTION
### What

- changed the tenses following the cert rotation
- removed the warning inset text, because users who don't accept the new cert for months won't remember one text message in June as 'being told about the rotation in advance'
- removed the line about restarting your device, as this won't really affect anything and I'm not sure why we put it here in the first place

### Why

So the content does not: 

- look out of date and neglected 
- confuse people if they read the guidance in a few months time and worry that they haven't been told about the rotation
