### PR TITLE
Add regular label for organisations filter

### DIFF
--- a/source/connect-to-govwifi/organisations-using-govwifi.html.erb
+++ b/source/connect-to-govwifi/organisations-using-govwifi.html.erb
@@ -19,7 +19,8 @@ description: Find all the public sector organisations where GovWifi is available
           please review our <%= link_to "technical requirements", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.
         </p>
         <div class="govuk-form-group govuk-!-margin-bottom-4">
-          <input class="govuk-input" aria-label="Search organisations using the service" id="search-table" type="text" placeholder="Search organisations">
+          <label class="govuk-label" for="search-table">Search organisations using the service</label>
+          <input class="govuk-input" id="search-table" type="text">
         </div>
 
         <% organisations = data.organisations.sort %>
@@ -30,7 +31,7 @@ description: Find all the public sector organisations where GovWifi is available
               <th class="govuk-table__header govuk-!-width-one-half table-header">Organisation</th>
             </tr>
           </thead>
-          <tbody class="govuk-table__body striped-table">
+          <tbody class="govuk-table__body striped-table" aria-live="polite">
             <% organisations.each do |organisation| %>
               <tr class="govuk-table__row result-row result">
                 <td class="govuk-table__cell govuk-!-width-one-half result-text" scope="row">


### PR DESCRIPTION
### What

Remove the placeholder and `aria-label` and replace with a regular label above.

Add `aria-live` to results area In lieu of the explicit search button.

### Why

> Users were not presented instructions or labels to identify the controls in a form and describe what input data is expected. Placeholder text has been used as the only visible labelling technique. Those with cognitive, language, and learning disabilities may find labels help them to enter information correctly. Labels may also help to prevent users from making submission errors. For voice activation users, visible labels can be used to indicate the accessible name by which this component may be referenced to assistive technology. Otherwise, users are required to use general commands such as ‘click box’.
> 
> When a user types, results update dynamically. However, there is nothing to inform screen reader users that this is happening. Users who mistakenly type into the field, or users who partially enter a search into the field without deleting the text again, may not realise that the organisations on the page are not the full list, but rather the search results corresponding to the text in the search field.
> 
> There is no explicit submit button to allow users to feel confident they have submitted their search.
> 
> Solution:
> 
> Ensure that users are informed that a change in content has occurred in response to entering text into the text field. An explicit search button is recommended.


Link to Trello card (if applicable): https://trello.com/c/tehYEQAG
