### PR TITLE
Remove `aria-label` from menu link, so it can be targeted in voice control

### DIFF
--- a/source/shared/_nav.html.erb
+++ b/source/shared/_nav.html.erb
@@ -8,8 +8,7 @@
   type="button"
   role="button"
   class="govuk-header__menu-button govuk-js-header-toggle"
-  aria-controls="navigation"
-  aria-label="Show or hide Top Level Navigation">
+  aria-controls="navigation">
   Menu
 </button>
 <nav>


### PR DESCRIPTION
### What
Remove the `aria-label` from the mobile Menu link.

### Why
When navigating using voice control, you would expect to be able to say "tap menu", however due to the `aria-label` you need to say "tap  Show or hide Top Level Navigation" which is not intuitive.

Link to Trello card (if applicable): https://trello.com/c/kyGO7y97
