### PR TITLE
Offer govwifi

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -43,7 +43,7 @@ description: GovWifi allows staff and visitors to use a single user login to con
           <p class="govuk-body">Make GovWifi available in your organisation and keep your existing infrastructure and
             wifi provider.</p>
           <p class="govuk-body">
-            <strong><%= link_to "Offer GovWifi", "https://docs.wifi.service.gov.uk", class: "govuk-link govuk-link--no-visited-state" %></strong>
+            <strong><%= link_to "Offer GovWifi", "/offer-govwifi", class: "govuk-link govuk-link--no-visited-state" %></strong>
           </p>
         </div>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -92,13 +92,13 @@
             <h2 class="govuk-footer__heading govuk-heading-m">Admin</h2>
             <ul class="govuk-footer__list footer-link-padding">
               <li class="govuk-footer__list-item">
-                <%= link_to 'Offer GovWifi in your organisation', 'https://docs.wifi.service.gov.uk/', class: "govuk-footer__link" %>
+                <%= link_to 'Offer GovWifi in your organisation', '/offer-govwifi/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Network Administrator login', 'https://admin.wifi.service.gov.uk/users/sign_in', class: "govuk-footer__link"%>
+                <%= link_to 'GovWifi admin', 'https://admin.wifi.service.gov.uk/users/sign_in', class: "govuk-footer__link"%>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Technical Documentation', 'https://docs.wifi.service.gov.uk/manage/#manage-govwifi', class: "govuk-footer__link" %>
+                <%= link_to 'Technical documentation', 'https://docs.wifi.service.gov.uk/', class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>

--- a/source/offer-govwifi.html.erb
+++ b/source/offer-govwifi.html.erb
@@ -1,0 +1,134 @@
+---
+title: Offer GovWifi - GovWifi
+description: Information for organisations about offering GovWifi.
+---
+
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+      </div>
+      <main class="govuk-grid-column-two-thirds" role="main" id="main">
+        <h1 class="govuk-heading-l">Offer GovWifi in your organisation</h1>
+        <p class="govuk-body">
+          GovWifi lets staff and visitors sign up once and then automatically connect to the wifi in multiple public sector buildings.
+        </p>
+        <p class="govuk-body">
+          The benefits of using GovWifi are:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>people do not have to sign up for and remember different usernames and passwords for wifi networks in everyone building they visit</li>
+          <li>people can sign up themselves by sending a text or email - removing admin that your organisation needs to do when expecting visitors</li>
+          <li>it’s more secure than using a single password, or ‘pre-shared key’ for your guest wifi network</li>
+          <li>you set it up over your existing infrastructure, so it’s quick to install</li>
+          <li>it's free</li>
+        </ul>
+        <h2 class="govuk-heading-m">What it's for</h2>
+        <p class="govuk-body">
+        GovWifi is designed to help users onto guest wifi networks.
+        </p>
+        <p class="govuk-body">
+        If you want to use it as the way to join the sole network in a building, please contact us first.
+        </p>
+        <p class="govuk-body">
+        You can connect any devices to GovWifi as long as they support WPA2 enterprise wifi and allow users to enter a username and password to connect. This usually includes desktops, laptops, tablets and smartphones, but may not include printers, monitors and speakers.
+        </p>
+        <h2 class="govuk-heading-m">Public sector organisations can offer it</h2>
+        <p class="govuk-body">
+        All UK public sector organisations can offer GovWifi. This means any organisation fully controlled or funded by the UK government. This includes:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>central government departments</li>
+          <li>local government</li>
+          <li>emergency services</li>
+          <li>NHS trusts</li>
+          <li>UK embassies and consulates</li>
+        </ul>
+        <p class="govuk-body">
+        You can see a list of the <a class="govuk-link" href="/connect-to-govwifi/organisations-using-govwifi">organisations that currently offer GovWifi</a>.
+        </p>
+        <p class="govuk-body">
+        If you're not sure your organisation is eligible, contact us.
+        </p>
+        <h2 class="govuk-heading-m">Anyone can use it</h2>
+        <p class="govuk-body">
+        Anyone can connect a device to GovWifi once they have signed up for a username and password. This includes:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>public sector workers</li>
+          <li>consultants and contractors</li>
+          <li>members of the public who need to work from public sector buildings - like lawyers and jurors in courts, or private sector workers collaborating with government</li>
+        </ul>
+        <h2 class="govuk-heading-m">It's free</h2>
+        <p class="govuk-body">
+        You do not need to pay to offer, or use GovWifi. The Cabinet Office operates the service and covers the cost of running it to make it simpler to collaborate across government.
+        </p>
+        <p class="govuk-body">
+        You need to cover the installation and ongoing operating and support costs of the network you’re using GovWifi on.
+        </p>
+        <h2 class="govuk-heading-m">How it works for your organisation</h2>
+        <p class="govuk-body">
+        To offer GovWifi, you need to configure your existing wifi infrastructure to support GovWifi and connect to our RADIUS servers and authenticate users.
+        </p>
+        <p class="govuk-body">
+        You can do this at your own pace by following our documentation and setting up an account in our self-service admin site.
+        </p>
+        <p class="govuk-body">
+        Once you’re set up, you need to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>advertise GovWifi in your buildings</li>
+          <li>monitor traffic and acceptable use</li>
+          <li>support your users if they have any problems</li>
+        </ul>
+        <h2 class="govuk-heading-m">How it works for your users</h2>
+        <p class="govuk-body">
+        A user can send a text or email to request a username and password.
+        </p>
+        <p class="govuk-body">
+        They will receive a randomly generated username and password in reply. They can enter these credentials to connect to the GovWifi network for the first time. They will then automatically connect to GovWifi in all buildings where it’s available.
+        </p>
+        <p class="govuk-body">
+        They can use those credentials to connect to the wifi on all their devices.
+        </p>
+        <h2 class="govuk-heading-m">What to expect from the GovWifi service</h2>
+        <p class="govuk-body">
+        The GovWifi service includes:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the GovWifi authentication service that lets your staff and visitors sign themselves up to use your wifi, which is maintained and improved by the GovWifi team</li>
+          <li>guidance for users on <a class="govuk-link" href="/connect-to-govwifi">how to connect to GovWifi</a>, including instructions for different operating systems and common troubleshooting steps</li>
+          <li>this <a class="govuk-link" href="https://docs.wifi.service.gov.uk/">technical documentation</a>, which covers how to configure your network and hardware to use the authentication service</li>
+          <li>a <a class="govuk-link" href="https://admin.wifi.service.gov.uk/">self-service admin site</a> where you can manage your IP addresses and locations, and see usage logs </li>
+          <li>a secure process for contacting your users, if you need to investigate misuse of your network or alert them to malware on their devices</li>
+          <li>support for your team managing the GovWifi network - we’re here Monday to Friday and will reply within 1 working day</li>
+          <li>alerts via our <a class="govuk-link" href="https://status.wifi.service.gov.uk">status page</a> if there’s an incident</li>
+        </ul>
+        <h2 class="govuk-heading-m">What the service does not include</h2>
+        <p class="govuk-body">
+        The GovWifi team does not provide:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>any hardware</li>
+          <li>onsite help with your network</li>
+          <li>support for GovWifi users in your building if they need help</li>
+        </ul>
+        <h2 class="govuk-heading-m">Data protection</h2>
+        <p class="govuk-body">
+        Information about data protection is set out in a Memorandum of understanding that you’ll need to agree to during the onboarding process. You can download and sign it from GovWifi admin.
+        </p>
+        <p class="govuk-body">
+        We explain data protection information to GovWifi users in our <a class="govuk-link" href="/privacy-notice/">privacy notice</a>.
+        </p>
+        <h2 class="govuk-heading-m">Get started</h2>
+        <p class="govuk-body">
+          Visit our technical documentation to see how to <a class="govuk-link" href="https://docs.wifi.service.gov.uk/">set up GovWifi</a>.
+        </p>
+        <h2 class="govuk-heading-s">Contact us</h2>
+        <p class="govuk-body">
+        Get in touch with the GovWifi team at <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a>
+        </p>
+        </div>
+    </div>
+  </div>
+</div>

--- a/source/shared/_nav.html.erb
+++ b/source/shared/_nav.html.erb
@@ -1,6 +1,6 @@
 <% nav_items = [
    { title: "Connect a device", root: "/connect-to-govwifi/", link: "/connect-to-govwifi"},
-   { title: "Offer GovWifi", link: "https://docs.wifi.service.gov.uk/" },
+   { title: "Offer GovWifi", link: "/offer-govwifi" },
    { title: "Admin", link: "https://admin.wifi.service.gov.uk/" }
 ] %>
 

--- a/source/terms-and-conditions.html.erb
+++ b/source/terms-and-conditions.html.erb
@@ -71,7 +71,7 @@ description: These terms apply to your use of GovWifi. You must agree to these t
           <li>
             GDS can change these terms and conditions at any time. We’ll tell you
             about any change by email or text message, at least 10 days before the
-            change happens. GDSwill specify the date the change will happen in the
+            change happens. GDS will specify the date the change will happen in the
             message you receive. If you don’t accept the change, you must stop
             using GovWifi.
           </li>
@@ -83,102 +83,6 @@ description: These terms apply to your use of GovWifi. You must agree to these t
           For GovWifi support for your managed device, contact your home organisation’s
           IT helpdesk. If it’s your own device ask your host organisation if they
           are able to help you.
-        </p>
-
-        <h2 class="govuk-heading-m">Terms and Conditions for Organisations</h2>
-        <p class="govuk-body">
-          GovWifi lets public sector workers work in other departments’ and agencies’
-          buildings without the need to register for the local guest wifi service.
-          It has been designed so that it can replace existing guest wifi services if
-          required. Organisations wanting to use GovWifi for other purposes should
-          contact GDS for advice.
-        </p>
-
-        <h3 class="govuk-heading-s">GDPR (General Data Protection Requirements)</h3>
-        <p class="govuk-body">
-          GDPR is covered in our Memorandum of Understanding (MoU). To confirm your
-          organisation’s acceptance of these data protection requirements you will
-          need to download and sign the MoU in the GovWifi Admin Portal.
-        </p>
-
-        <h3 class="govuk-heading-s">Services and Standards</h3>
-        <p class="govuk-body">
-          GDS will provide the GovWifi Authentication Service to the participating
-          organisation to allow Users to self-enrol and connect to the local wifi
-          network. Once enrolled, the credentials created can then be saved to the
-          User’s mobile device and will allow the User to seamlessly access GovWifi
-          in any participating Government location. GDS will also provide:
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            the GovWifi Authentication Service, removing the burden of deploying
-            and maintaining authentication systems across government premises
-          </li>
-          <li>
-            simple and coherent methods for self-enrolment and guest enrolment
-            onto the GovWifi Authentication Service
-          </li>
-          <li>
-            guidance on how to configure locally procured / installed hardware
-            to use the Authentication Service
-          </li>
-          <li>
-            guidance on how to configure departmentally-controlled end user
-            devices to connect to the service in any participating location
-          </li>
-        </ul>
-
-        <h3 class="govuk-heading-s">GDS will not be responsible for:</h3>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>providing hardware that lets you to access the GovWifi Authentication Service</li>
-          <li>
-            specifying, managing, installing or certifying any changes to existing
-            services and/or network cabling or connections to facilitate or improve
-            access to the GovWifi Authentication Service
-          </li>
-        </ul>
-
-        <h3 class="govuk-heading-s">Supplier payments</h3>
-        <p class="govuk-body">GDS:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            will cover the cost of development and operation of the GovWifi
-            Authentication Service
-          </li>
-          <li>
-            will not charge the organisation for the use of the GovWifi
-            Authentication Service
-          </li>
-        </ul>
-
-        <p class="govuk-body">
-          The participating organisation will secure in-building infrastructure
-          and use network intrusion detection at least sufficient to detect threats
-          such as unauthorised access points.
-        </p>
-
-        <h3 class="govuk-heading-s">Support for GovWifi</h3>
-        <p class="govuk-body">GDS:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            will provide a support service during standard UK office hours to the
-            Department’s IT teams
-          </li>
-          <li>
-            will not provide a support service directly to Users.
-          </li>
-        </ul>
-        <p class="govuk-body">
-          GDS services are not designed for, or intentionally targeted at, children
-          13 years of age or younger. It is not our policy to intentionally collect
-          or maintain data about anyone 13 years of age or younger. Therefore each
-          organisation is responsible for its own Privacy of Data management under
-          the Data Protection Legislation/GDPR. GovWifi is currently in public beta
-          which means that it is being continually tested and improved as part of
-          ongoing research. Any amendments to the terms and conditions will be notified
-          to your department’s nominated site administrators within seven working days
-          of the amendment being made.
         </p>
       </div>
     </div>


### PR DESCRIPTION
### What

- Add 'Offer GovWifi' page for organisations on the product site 
- Change the link on the homepage to go here 
- Changed the top nav so there's a link to this page, and a separate link to the documentation 

### Why
We didn't have any content aimed at decision-makers that explained the wider service offer. Possibly as a result of this, we'd also seen lots of organisations who hadn't understood some key things about the service before setting it up e.g. that they needed to provide support. 

This page is a bit of a test to see if it's useful. 

Link to Trello card: https://trello.com/c/qBRoO4nF
