### PR TITLE
Use the builtin set_pipeline in ci/pipelines/build-and-deploy.yml

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -18,11 +18,6 @@ resource_types:
     password: ((docker_hub_authtoken))
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-product-page
     type: git
     source:
@@ -63,19 +58,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-product-page
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-product-page}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipelines/build-and-deploy.yml
-        PIPELINE_NAME: product-page-deploy
+    - set_pipeline: product-page-deploy
+      file: govwifi-product-page/ci/pipelines/build-and-deploy.yml
 
   - name: build
     interruptible: true


### PR DESCRIPTION
### What
Use the builtin set_pipeline in ci/pipelines/build-and-deploy.yml

### Why
This avoids using the deprecated tech-ops task, and works better with
the GovWifi Concourse.
