### PR TITLE
Add performance metrics

### DIFF
--- a/source/offer-govwifi.html.erb
+++ b/source/offer-govwifi.html.erb
@@ -194,6 +194,62 @@ description: Information for organisations about offering GovWifi.
           <li>onsite help with your network</li>
           <li>support for GovWifi users in your building if they need help</li>
         </ul>
+
+        <h2 id="perf-data" class="govuk-heading-m">Performance data</h2>
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <h2 class="govuk-body-m govuk-!-margin-bottom-1">In the last week:</h2>
+          </div>
+          <div class="govuk-grid-column-one-third">
+            <div class="big-number">
+            <span class="big-number__value">
+              100%
+            </span>
+              <span class="govuk-visually-hidden">&nbsp;</span>
+              <span class="big-number__label">
+              Service uptime
+            </span>
+            </div>
+          </div>
+          <div class="govuk-grid-column-two-thirds">
+            <p class="intro-para">
+              <b>80,000</b>
+              people have used the service at least once,
+              <b>20,000</b>
+              have used it to work from multiple locations.
+            </p>
+          </div>
+        </div>
+
+        <div class="govuk-grid-row govuk-!-margin-bottom-4">
+          <div class="govuk-grid-column-full">
+            <h2 class="govuk-body-m govuk-!-margin-bottom-1">Since August 2016:</h2>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <div class="big-number">
+            <span class="big-number__value">
+              500k
+            </span>
+              <span class="govuk-visually-hidden">&nbsp;</span>
+              <span class="big-number__label">
+              Registered users
+            </span>
+            </div>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <div class="big-number">
+            <span class="big-number__value">
+              5k
+            </span>
+              <span class="govuk-visually-hidden">&nbsp;</span>
+              <span class="big-number__label">
+              Registered organisations
+            </span>
+            </div>
+          </div>
+        </div>
+
         <h2 class="govuk-heading-m">Data protection</h2>
         <p class="govuk-body">
         Information about data protection is set out in a memorandum of understanding that you’ll need to agree to during the onboarding process. You can download and sign it from GovWifi admin.

--- a/source/offer-govwifi.html.erb
+++ b/source/offer-govwifi.html.erb
@@ -3,13 +3,96 @@ title: Offer GovWifi - GovWifi
 description: Information for organisations about offering GovWifi.
 ---
 
-<div class="govuk-width-container">
-  <div class="govuk-main-wrapper">
+<div class="govuk-width-container ">
+  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
+        <h2 class="gem-c-contents-list__title">
+          Contents
+        </h2>
+        <ol class="gem-c-contents-list__list">
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#offer-govwifi">
+              Offer GovWifi in your organisation
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#what-its-for">
+              What it's for
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#orgs-that-use">
+              Public sector organisations can offer it
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#anyone">
+              Anyone can use it
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#free">
+              It's free
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#how-it-works">
+              How it works for your organisation
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#what-to-expect">
+              What to expect from the GovWifi service
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#whats-not-included">
+              What the service does not include
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#perf-data">
+              Performance data
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#data-protection">
+              Data protection
+            </a>
+          </li>
+          <li class="gem-c-contents-list__list-item">
+            <a
+              class="gem-c-contents-list__link govuk-link govuk-link--no-underline"
+              href="#get-started">
+              Get started
+            </a>
+          </li>
+        </ol>
+        </nav>
       </div>
-      <main class="govuk-grid-column-two-thirds" role="main" id="main">
-        <h1 class="govuk-heading-l">Offer GovWifi in your organisation</h1>
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+        <h1 id="offer-govwifi" class="govuk-heading-l">Offer GovWifi in your organisation</h1>
         <p class="govuk-body">
           GovWifi lets staff and visitors sign up once and then automatically connect to the wifi in multiple public sector buildings.
         </p>
@@ -23,17 +106,17 @@ description: Information for organisations about offering GovWifi.
           <li>you set it up over your existing infrastructure, so it’s quick to install</li>
           <li>it's free</li>
         </ul>
-        <h2 class="govuk-heading-m">What it's for</h2>
+        <h2 id="what-its-for" class="govuk-heading-m">What it's for</h2>
         <p class="govuk-body">
         GovWifi is designed to help users onto guest wifi networks.
         </p>
-        <p class="govuk-body">
+        <div class="govuk-inset-text">
         If you want to use it as the way to join the sole network in a building, please contact us first.
-        </p>
+        </div>
         <p class="govuk-body">
         You can connect any devices to GovWifi as long as they support WPA2 enterprise wifi and allow users to enter a username and password to connect. This usually includes desktops, laptops, tablets and smartphones, but may not include printers, monitors and speakers.
         </p>
-        <h2 class="govuk-heading-m">Public sector organisations can offer it</h2>
+        <h2 id="orgs-that-use" class="govuk-heading-m">Public sector organisations can offer it</h2>
         <p class="govuk-body">
         All UK public sector organisations can offer GovWifi. This means any organisation fully controlled or funded by the UK government. This includes:
         </p>
@@ -50,7 +133,7 @@ description: Information for organisations about offering GovWifi.
         <p class="govuk-body">
         If you're not sure your organisation is eligible, contact us.
         </p>
-        <h2 class="govuk-heading-m">Anyone can use it</h2>
+        <h2 id="anyone" class="govuk-heading-m">Anyone can use it</h2>
         <p class="govuk-body">
         Anyone can connect a device to GovWifi once they have signed up for a username and password. This includes:
         </p>
@@ -59,14 +142,14 @@ description: Information for organisations about offering GovWifi.
           <li>consultants and contractors</li>
           <li>members of the public who need to work from public sector buildings - like lawyers and jurors in courts, or private sector workers collaborating with government</li>
         </ul>
-        <h2 class="govuk-heading-m">It's free</h2>
+        <h2 id="free" class="govuk-heading-m">It's free</h2>
         <p class="govuk-body">
         You do not need to pay to offer, or use GovWifi. The Cabinet Office operates the service and covers the cost of running it to make it simpler to collaborate across government.
         </p>
         <p class="govuk-body">
         You need to cover the installation and ongoing operating and support costs of the network you’re using GovWifi on.
         </p>
-        <h2 class="govuk-heading-m">How it works for your organisation</h2>
+        <h2 id="how-it-works" class="govuk-heading-m">How it works for your organisation</h2>
         <p class="govuk-body">
         To offer GovWifi, you need to configure your existing wifi infrastructure to support GovWifi and connect to our RADIUS servers and authenticate users.
         </p>
@@ -80,18 +163,16 @@ description: Information for organisations about offering GovWifi.
           <li>advertise GovWifi in your buildings</li>
           <li>monitor traffic and acceptable use</li>
           <li>support your users if they have any problems</li>
+          <li>How it works for your users</li>
+          <li>A user can send a text or email to request a username and password.</li>
         </ul>
-        <h2 class="govuk-heading-m">How it works for your users</h2>
-        <p class="govuk-body">
-        A user can send a text or email to request a username and password.
-        </p>
         <p class="govuk-body">
         They will receive a randomly generated username and password in reply. They can enter these credentials to connect to the GovWifi network for the first time. They will then automatically connect to GovWifi in all buildings where it’s available.
         </p>
         <p class="govuk-body">
         They can use those credentials to connect to the wifi on all their devices.
         </p>
-        <h2 class="govuk-heading-m">What to expect from the GovWifi service</h2>
+        <h2 id="what-to-expect" class="govuk-heading-m">What to expect from the GovWifi service</h2>
         <p class="govuk-body">
         The GovWifi service includes:
         </p>
@@ -104,7 +185,7 @@ description: Information for organisations about offering GovWifi.
           <li>support for your team managing the GovWifi network - we’re here Monday to Friday and will reply within 1 working day</li>
           <li>alerts via our <a class="govuk-link" href="https://status.wifi.service.gov.uk">status page</a> if there’s an incident</li>
         </ul>
-        <h2 class="govuk-heading-m">What the service does not include</h2>
+        <h2 id="whats-not-included" class="govuk-heading-m">What the service does not include</h2>
         <p class="govuk-body">
         The GovWifi team does not provide:
         </p>
@@ -117,10 +198,10 @@ description: Information for organisations about offering GovWifi.
         <p class="govuk-body">
         Information about data protection is set out in a memorandum of understanding that you’ll need to agree to during the onboarding process. You can download and sign it from GovWifi admin.
         </p>
-        <p class="govuk-body">
+        <p id="data-protection" class="govuk-body">
         We explain data protection information to GovWifi users in our <a class="govuk-link" href="/privacy-notice/">privacy notice</a>.
         </p>
-        <h2 class="govuk-heading-m">Get started</h2>
+        <h2 id="get-started" class="govuk-heading-m">Get started</h2>
         <p class="govuk-body">
           Visit our technical documentation to see how to <a class="govuk-link" href="https://docs.wifi.service.gov.uk/">set up GovWifi</a>.
         </p>
@@ -130,5 +211,5 @@ description: Information for organisations about offering GovWifi.
         </p>
         </div>
     </div>
-  </div>
+  </main>
 </div>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -13,6 +13,10 @@
 @import "modules/skip-link";
 @import "modules/striped-table";
 @import "modules/sub-navigation";
+@import "modules/govuk_publishing_components/mixins/govuk-template-link-focus-override";
+@import "modules/govuk_publishing_components/helpers/contents-list-helper";
+@import "modules/govuk_publishing_components/print/contents-list";
+@import "modules/govuk_publishing_components/components/contents-list";
 
 html,
 body {

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -17,6 +17,7 @@
 @import "modules/govuk_publishing_components/helpers/contents-list-helper";
 @import "modules/govuk_publishing_components/print/contents-list";
 @import "modules/govuk_publishing_components/components/contents-list";
+@import "patterns/big-number";
 
 html,
 body {
@@ -31,3 +32,9 @@ body {
   background-color: govuk-colour('white');
 }
 // scss-lint:enable IdSelector
+
+.intro-para {
+  @include govuk-font($size: 24);
+  padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(4);
+  border-left: 3px solid govuk-colour("blue");
+}

--- a/source/stylesheets/modules/govuk_publishing_components/components/_contents-list.scss
+++ b/source/stylesheets/modules/govuk_publishing_components/components/_contents-list.scss
@@ -1,0 +1,74 @@
+.gem-c-contents-list {
+  // Always render the contents list above a
+  // back to contents link
+  position: relative;
+  margin: 0 0 govuk-spacing(4) 0;
+  z-index: 1;
+  background: govuk-colour("white");
+  box-shadow: 0 20px 15px -10px govuk-colour("white");
+}
+
+.gem-c-contents-list__title {
+  @include govuk-text-colour;
+  @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+  margin: 0;
+}
+
+.gem-c-contents-list__list,
+.gem-c-contents-list__nested-list {
+  @include govuk-text-colour;
+  @include govuk-font($size: 16);
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.gem-c-contents-list__link {
+  .gem-c-contents-list__list-item--parent > & {
+    font-weight: bold;
+  }
+
+  @include govuk-template-link-focus-override;
+}
+
+.gem-c-contents-list__list-item {
+  padding-top: govuk-spacing(2);
+  line-height: 1.3;
+  list-style-type: none;
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(6) / 4;
+  }
+}
+
+.gem-c-contents-list__list-item--dashed {
+  $contents-spacing: govuk-spacing(5);
+  position: relative;
+  padding-left: $contents-spacing;
+  padding-right: $contents-spacing;
+
+  &:before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    width: govuk-spacing(4);
+    overflow: hidden;
+
+    .direction-rtl & {
+      left: auto;
+      right: 0;
+    }
+  }
+
+  // Focus styles on IE8 and older include the
+  // left margin, creating an odd white box with
+  // orange border around the em dash.
+  // Use inline-block and vertical alignment to
+  // fix focus styles
+  //
+  // https://github.com/alphagov/government-frontend/pull/420#issuecomment-320632386
+  .lte-ie8 & .gem-c-contents-list__link {
+    display: inline-block;
+    vertical-align: top;
+  }
+}

--- a/source/stylesheets/modules/govuk_publishing_components/helpers/_contents-list-helper.scss
+++ b/source/stylesheets/modules/govuk_publishing_components/helpers/_contents-list-helper.scss
@@ -1,0 +1,25 @@
+// Contents list helper is used in both print and screen stylesheets
+.gem-c-contents-list__list-item--numbered {
+  .gem-c-contents-list__link {
+    display: table;
+  }
+}
+
+.gem-c-contents-list__number,
+.gem-c-contents-list__numbered-text {
+  display: table-cell;
+}
+
+.gem-c-contents-list__number {
+  min-width: 1.5em;
+}
+
+.gem-c-contents-list__numbered-text {
+  $contents-text-padding: .3em;
+  padding-left: $contents-text-padding;
+
+  .direction-rtl & {
+    padding-left: 0;
+    padding-right: $contents-text-padding;
+  }
+}

--- a/source/stylesheets/modules/govuk_publishing_components/mixins/_govuk-template-link-focus-override.scss
+++ b/source/stylesheets/modules/govuk_publishing_components/mixins/_govuk-template-link-focus-override.scss
@@ -1,0 +1,14 @@
+// TODO: Remove when appropriate
+// govuk_template overrides the styles set by
+// govuk-frontend 3.0.0. This mixin is intended as a temporary fix
+// to ensure focus styles are as expected in apps using govuk_template
+
+@mixin govuk-template-link-focus-override {
+  &:focus,
+  &:active:focus,
+  &:link:focus,
+  &:visited:focus {
+    @include govuk-focused-text;
+    color: govuk-colour("black") !important; // stylelint-disable-line declaration-no-important
+  }
+}

--- a/source/stylesheets/modules/govuk_publishing_components/print/_contents-list.scss
+++ b/source/stylesheets/modules/govuk_publishing_components/print/_contents-list.scss
@@ -1,0 +1,17 @@
+// Override default browser indentation
+.gem-c-contents-list__list,
+.gem-c-contents-list__nested-list {
+  padding-left: 0;
+  margin-left: 0;
+}
+
+// Put indentation back where we use list style types
+.gem-c-contents-list__list-item--dashed {
+  margin-left: govuk-spacing(3);
+  list-style-type: disc;
+}
+
+.gem-c-contents-list__list-item--numbered,
+.gem-c-contents-list__list-item--parent {
+  list-style-type: none;
+}

--- a/source/stylesheets/patterns/_big-number.scss
+++ b/source/stylesheets/patterns/_big-number.scss
@@ -1,0 +1,36 @@
+.big-number {
+  margin: govuk-spacing(1) 0 govuk-spacing(3);
+}
+
+.big-number__value {
+  @include govuk-font($size: 48, $weight: bold);
+
+  @include govuk-media-query ($from: desktop) {
+    font-size: 74px;
+  }
+
+  @media print {
+    font-family: sans-serif;
+    font-size: 53pt;
+    line-height: 1.1;
+  }
+}
+
+.big-number__label {
+  @include govuk-font($size: 14, $weight: bold);
+
+  @include govuk-media-query ($from: desktop) {
+    @include govuk-font($size: 16, $weight: bold);
+  }
+
+  @media print {
+    font-family: sans-serif;
+    font-size: 14pt;
+    line-height: 1.1;
+  }
+}
+
+.big-number__label:before {
+  content: "";
+  display: block;
+}


### PR DESCRIPTION
### What
Add a new index pane and static performance numbers to the 'Offer Govwifi page'

### Why
We want to inform potential customers of our performance numbers.

Link to Trello card (if applicable): 
https://trello.com/c/2JVIdEcE/1805-write-performance-metrics-for-product-page

![image](https://user-images.githubusercontent.com/6050162/146805619-bfeda7fd-306d-4aef-bf43-472610daa891.png)
![image](https://user-images.githubusercontent.com/6050162/146805662-52e40576-d31f-4267-adb3-022430d79d07.png)
