### PR TITLE
Ensure the tests work by running them under the 'build' environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Capybara.default_driver = :selenium_chrome_headless
 
 middleman_app = ::Middleman::Application.new do
   set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  set :environment, :development
+  set :environment, :build
   set :show_exceptions, false
 end
 


### PR DESCRIPTION
The tests previously ran under the development environment. The development
environment includes livereloading, which requires
loading a number of gems. This is fine when running Middleman, but
not when running tests as the spec_helper does not require the gems.

This commit sets the environment the tests run under as 'build', which
ensures the tests work.
