### PR TITLE
Bump `govwifi-shared-frontend` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,16 @@
       "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
     },
     "govwifi-shared-frontend": {
-      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.5/govwifi-shared-frontend-0.6.5.tgz",
-      "integrity": "sha512-fpYi2op7XDuQe6pkrBHNgdHkVFcV09TGbv03mOMQnerUgRtx9fMHLug7t3RE/dl/M0+uT4xBPf3tiGG9ur/2qQ==",
+      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz",
+      "integrity": "sha512-9m+5a7PmfOL2dHQfdAeynH2xEfoiREC2g5af5KmgCLLwqCEkDnLhXKwVkE0zl84d0X/nODbbseYKVnLTY45vzQ==",
       "requires": {
-        "js-cookie": "^2.2.1"
+        "js-cookie": "^3.0.1"
       }
     },
     "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^3.14.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.5/govwifi-shared-frontend-0.6.5.tgz"
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What

Bump `govwifi-shared-frontend` to the latest release version.

### Why

A new version of the repo was released today, this will ensure we're using the newest version.

I've run the app locally and can't find any breaking changes.

