### PR TITLE
Bump `govwifi-shared-frontend` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,55 @@
 {
   "name": "govwifi-product-page",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "govwifi-product-page",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaap-analytics": "^3.1.0",
+        "govuk-frontend": "^4.0.1",
+        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
+      }
+    },
+    "node_modules/gaap-analytics": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gaap-analytics/-/gaap-analytics-3.1.0.tgz",
+      "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
+    },
+    "node_modules/govuk-frontend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/govwifi-shared-frontend": {
+      "version": "0.6.8",
+      "resolved": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-cookie": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "npm": ">=8.4.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
   "dependencies": {
     "gaap-analytics": {
       "version": "3.1.0",
@@ -15,8 +62,8 @@
       "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
     },
     "govwifi-shared-frontend": {
-      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz",
-      "integrity": "sha512-9m+5a7PmfOL2dHQfdAeynH2xEfoiREC2g5af5KmgCLLwqCEkDnLhXKwVkE0zl84d0X/nODbbseYKVnLTY45vzQ==",
+      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
       "requires": {
         "js-cookie": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^4.0.1",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz"
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What

Bump the release version to `0.6.8` to match what's in GitHub.

### Why

There's a new release of `govwifi-shared-frontend` (see [here](https://github.com/alphagov/govwifi-shared-frontend/releases/tag/v0.6.8)), we need to be keeping up with the changes.
