### PR TITLE
Update certificate page to include 2022 certificate rotation information

### DIFF
--- a/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
+++ b/source/connect-to-govwifi/update-govwifi-server-certificate.html.erb
@@ -10,12 +10,13 @@ description: Information about accepting the new GovWifi server certificate to k
       </div>
       <main class="govuk-grid-column-two-thirds" role="main" id="main">
         <h1 class="govuk-heading-l">Accept the new GovWifi certificate</h1>
-        <p class="govuk-body">On 5 July 2021, we renewed the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine network.</p>
+        <p class="govuk-body">On 31 May 2022, we’ll renew the GovWifi ‘certificate’. Your device checks this certificate each time you connect to GovWifi to make sure it’s connecting to the genuine GovWifi network.</p>
         <p class="govuk-body">You might need to accept the new certificate on your device to continue using GovWifi.</p>
+        <p class="govuk-body">If you’re ever asked to accept a new certificate without being told in advance by the GovWifi team, do not accept it. Report it to the IT support desk for the building you’re in.</p>
 
         <h2 class="govuk-heading-m">What to do depends on your device</h2>
 
-        <p class="govuk-body">The next time you try to connect to GovWifi, your device might automatically check the new certificate and accept it. In this case, you will not need to do anything.</p>
+        <p class="govuk-body">Your device might automatically check the new certificate and accept it. In this case, you will not need to do anything.</p>
 
         <p class="govuk-body">Or, you may be asked to accept the new certificate.</p>
 
@@ -24,7 +25,7 @@ description: Information about accepting the new GovWifi server certificate to k
           <li>View the certificate.</li>
           <li>Check that the domain is <strong>wifi.service.gov.uk</strong></li>
           <li>Check the issuer is <strong>GeoTrust TLS DV RSA Mixed SHA256 2020 CA-1</strong></li>
-          <li>Check the fingerprint or thumbprint is <strong>AC 70 5D 2B 63 36 4B 3C A4 1D 13 8E 9B F7 11 E7 21 E9 E6 2A</strong></li>
+          <li>Check the fingerprint or thumbprint is <strong>2A A4 70 43 4F 33 81 5C F7 C4 F7 85 60 46 52 27 F1 AD C9 6A</strong></li>
           <li>Accept or trust the new certificate.</li>
         </ol>
 
@@ -32,13 +33,13 @@ description: Information about accepting the new GovWifi server certificate to k
 
         <h2 class="govuk-heading-m">If you're having problems</h2>
 
-        <p class="govuk-body">If you’re on a work device, contact the organisation that gave you the device. You may not have permission to accept the new certificate.</p>
+        <p class="govuk-body">If you’re on a work device, contact the organisation that gave you the device as you may not have permission to accept the new certificate.</p>
 
-        <p class="govuk-body">You can also:</p>
+        <p class="govuk-body">If you’ve accepted the certificate but you still cannot connect:</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li>forget the network and try again</li>
-          <li>follow our <%= link_to "guidance on common issues", "/connect-to-govwifi/get-help-connecting", class: "govuk-link" %></li>
+          <li>forget the network and try to connect again</li>
+          <li>follow our guidance on <%= link_to "common issues with GovWifi", "/connect-to-govwifi/get-help-connecting", class: "govuk-link" %></li>
           <li>contact the IT support desk for the building you're in</li>
         </ul>
 


### PR DESCRIPTION
### What
Update certificate page to include 2022 certificate rotation information
### Why
We are about to start the certificate rotation process. This PR updates the information on the relevant page.

Link to Trello card (if applicable): 
https://trello.com/c/l2DwDfyP/2300-our-product-page-accept-the-new-certificate-is-out-of-date

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/6050162/170299966-c81befa5-63fa-40c2-be7c-7f791f244b54.png">

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6050162/170300048-f3d7180f-5b1a-499d-92f4-ce4cfa913b41.png">
