### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM governmentpaas/cf-cli@sha256:524554e6bcd9e77e9f3886de0ee2c1307976361a41a009b4690c709afd52812e
+FROM governmentpaas/cf-cli@sha256:5fc9987476f0d435faa07cd0541e9963e0cf965d56ff7c5fe2a54f85097a444c
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
### What
Update docker image

### Why
We recently upgraded Capybara to a version that is incompatible with
Ruby version 2.6. The old docker image contained that version and
broke running the server locally

The new docker version contains Ruby 2.7.2, which is compatible