### PR TITLE
Update SHA fingerprint in Windows and iPhone pages

### DIFF
--- a/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
+++ b/source/connect-to-govwifi/device-iphone-or-ipad.html.erb
@@ -29,7 +29,7 @@ description: Follow these instructions to connect your iPhone or iPad to GovWifi
           <li><p class="govuk-body">Select <strong>More Details</strong> and scroll down to the 'Fingerprints' section at the bottom of the page.</p></li>
           <li>
             <p class="govuk-body"><p>Check that the SHA-1 Fingerprint matches:</p>
-            <p class="govuk-body"> <strong>AC 70 5D 2B 63 36 4B 3C A4 1D 13 8E 9B F7 11 E7 21 E9 E6 2A</strong></p>
+            <p class="govuk-body"> <strong>2A A4 70 43 4F 33 81 5C F7 C4 F7 85 60 46 52 27 F1 AD C9 6A</strong></p>
             <div class="govuk-inset-text">If the certificate details are not correct, tell IT support and do not join the network.</div>
           </li>
           <li>

--- a/source/connect-to-govwifi/device-windows.html.erb
+++ b/source/connect-to-govwifi/device-windows.html.erb
@@ -48,7 +48,7 @@ description: Follow these instructions to connect your Windows device to GovWifi
           </li>
           <li>
             <p class="govuk-body">Check that the <strong>Server thumbprint</strong> matches: </p>
-            <p class="govuk-body"><strong>AC 70 5D 2B 63 36 4B 3C A4 1D 13 8E 9B F7 11 E7 21 E9 E6 2A</strong></p>
+            <p class="govuk-body"><strong>2A A4 70 43 4F 33 81 5C F7 C4 F7 85 60 46 52 27 F1 AD C9 6A</strong></p>
           </li>
           <li>
             <p class="govuk-body">If it matches, select <strong>Connect</strong>. If it does not match, tell IT support and do not join the network.</p>


### PR DESCRIPTION
### What
Update SHA fingerprint in Windows and iPhone pages

### Why
To reflect the new fingerprint following certificate rotation on
30/05/22.

Link to Trello card (if applicable): 
https://trello.com/c/gUcJ5irN/2302-our-product-page-connect-to-govwifi-using-a-windows-device
https://trello.com/c/0Y00SO4z/2301-our-product-page-connect-to-govwifi-using-an-iphone-or-ipad-is-out-of-date
