### PR TITLE
Update device-android.html.erb

### DIFF
--- a/source/connect-to-govwifi/device-android.html.erb
+++ b/source/connect-to-govwifi/device-android.html.erb
@@ -29,7 +29,7 @@ description: Follow these instructions to connect your Android device to GovWifi
             <p class="govuk-body">For <strong>Phase 2 authentication</strong>, select <strong>MSCHAPV2</strong>.</p>
           </li>
           <li>
-            <p class="govuk-body">For <strong>CA Certificate</strong>, select <strong>Use system certificates</strong>.</p>
+            <p class="govuk-body">For <strong>CA Certificate</strong>, select <strong>Use system certificates</strong> - if this option is not shown select <strong>Do not validate</strong>.</p>
           </li>
           <li>
             <p class="govuk-body">For <strong>Domain</strong>, enter wifi.service.gov.uk</p>


### PR DESCRIPTION


### What
Text change to line 32 use system certificates - approved by Seb.
### Why
Text on system certs for Android devices was incorrect.


Link to Trello card (if applicable): https://trello.com/c/sYAdsxVR/1442-connect-to-govwifi-guidance-is-not-consistent-product-page-and-text-help
