### PR TITLE
Sidebar navigation updated to remove Blackberry

### DIFF
--- a/source/shared/product/_sidebar.html.erb
+++ b/source/shared/product/_sidebar.html.erb
@@ -5,7 +5,6 @@
   { title: "Connect using a Windows device", link: "/connect-to-govwifi/device-windows/" },
   { title: "Connect using a Mac", link: "/connect-to-govwifi/device-mac/" },
   { title: "Connect using a Chromebook", link: "/connect-to-govwifi/device-chromebook/" },
-  { title: "Connect using a BlackBerry", link: "/connect-to-govwifi/device-blackberry/" },
   { title: "Get help connecting", link: "/connect-to-govwifi/get-help-connecting/" },
   { title: "Organisations using GovWifi", link: "/connect-to-govwifi/organisations-using-govwifi/" },
   { title: "Accept the new GovWifi certificate", link: "/connect-to-govwifi/update-govwifi-server-certificate/" }


### PR DESCRIPTION
### What
Sidebar navigation updated to remove Blackberry

### Why
Blackberry guidance now withdrawn. Sidebar nav update to remove link to Blackberry guidance.


Link to Trello card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-295
