### PR TITLE
List of devices updated to remove Blackberry

### DIFF
--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -28,9 +28,8 @@ description: How to connect devices to GovWifi.
           <a class="govuk-link" href="/connect-to-govwifi/device-android">Android</a>,
           <a class="govuk-link" href="/connect-to-govwifi/device-iphone-or-ipad">iPhone or iPad</a>,
           <a class="govuk-link" href="/connect-to-govwifi/device-mac">Mac</a>,
-          <a class="govuk-link" href="/connect-to-govwifi/device-windows">Windows</a>,
-          <a class="govuk-link" href="/connect-to-govwifi/device-chromebook">Chromebook</a> or
-          <a class="govuk-link" href="/connect-to-govwifi/device-blackberry">BlackBerry</a>.
+          <a class="govuk-link" href="/connect-to-govwifi/device-windows">Windows</a> or
+          <a class="govuk-link" href="/connect-to-govwifi/device-chromebook">Chromebook</a>.
         </p>
         <p class="govuk-body">You can use the same username and password to connect all your devices to GovWifi.</p>
         <div class="govuk-inset-text">


### PR DESCRIPTION

### What
List of devices updated to remove Blackberry

### Why
Blackberry guidance now removed, list of devices updated to remove link to Blackberry.


Link to Trello card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-295
