### PR TITLE
Remove reference to Blackberry

### DIFF
--- a/source/connect-to-govwifi/get-help-connecting.html.erb
+++ b/source/connect-to-govwifi/get-help-connecting.html.erb
@@ -66,9 +66,8 @@ description: Get help with any problems you have connecting to GovWifi.
               <a class="govuk-link" href="/connect-to-govwifi/device-android">Android</a>,
               <a class="govuk-link" href="/connect-to-govwifi/device-iphone-or-ipad">iPhone or iPad</a>,
               <a class="govuk-link" href="/connect-to-govwifi/device-mac">Mac</a>,
-              <a class="govuk-link" href="/connect-to-govwifi/device-windows">Windows</a>,
-              <a class="govuk-link" href="/connect-to-govwifi/device-chromebook">Chromebook</a> and
-              <a class="govuk-link" href="/connect-to-govwifi/device-blackberry">BlackBerry</a>
+              <a class="govuk-link" href="/connect-to-govwifi/device-windows">Windows</a> and
+              <a class="govuk-link" href="/connect-to-govwifi/device-chromebook">Chromebook</a>
             </li>
             <li>
               contact the IT support desk for the building you’re in - connection problems are usually due to the local network or your device


### PR DESCRIPTION


### What
Guidance for Blackberry is now withdrawn, this text change removes a reference to Blackberry

### Why
Blackberry is end of life, guidance withdrawn.


Link to Trello card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-295
