### PR TITLE
add shorter url and redirect

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -61,6 +61,7 @@ redirect "about-govwifi.html", to: "https://docs.wifi.service.gov.uk/"
 redirect "about-govwifi/how-govwifi-works.html", to: "https://docs.wifi.service.gov.uk/"
 redirect "about-govwifi/organisations-using-govwifi.html", to: "/connect-to-govwifi/organisations-using-govwifi/"
 
+redirect "help.html", to: "/connect-to-govwifi/get-help-connecting/?utm_source=Organic&utm_medium=SMS&utm_campaign=Help"
 redirect "support.html", to: "/connect-to-govwifi/get-help-connecting/"
 redirect "support/update-govwifi-server-certificate.html", to: "/connect-to-govwifi/update-govwifi-server-certificate/"
 redirect "support/check-organisation-email-address.html", to: "/connect-to-govwifi/check-organisation-email-address/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     volumes:
       - ".:/usr/src/app"
-      - "node_modules"
+      - "/node_modules"
     ports:
       - "4567:4567"
       - "35729:35729"


### PR DESCRIPTION
### What
Create a shorted url redirect

### Why
The URL is too long and we can not track where users have come from (web page, notify text, poster, etc). This means we do not know how useful our support page is. We want to differentiate between users going to support via text help vs users going to support page via web.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-164