### PR TITLE
Add Lancashire County Council to orgs list

### DIFF
--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -71,6 +71,7 @@
 - Islington Council
 - Kent and Essex Police
 - Kent county council
+- Lancashire County Council
 - Lichfield District Council
 - London Borough of Brent
 - London Borough of Hackney


### PR DESCRIPTION
### What

Add Lancashire County Council to orgs list

### Why

The requested to be added.

Zendesk ticked 5169778
