### PR TITLE
Reference to Beta removed from privacy notice

### DIFF
--- a/source/privacy-notice.html.erb
+++ b/source/privacy-notice.html.erb
@@ -26,9 +26,6 @@ description: Find details about the GovWifi privacy policy and how we collect an
           The Cabinet Office determines how and why personal data is processed.
           <%= link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053", class: "govuk-link" %> for more information.
         </p>
-        <p class="govuk-body">
-          GovWifi is currently in public beta, which means we’re still testing and improving it.
-        </p>
         <h2 class="govuk-heading-m" id="what-data-we-need">What data we collect from you</h2>
         <p class="govuk-body">
           In order that GovWifi can work effectively for you we collect the following data:


### PR DESCRIPTION
### What
Text reference to Beta removed.

### Why
Factually wrong

### Jira
[GW-793](https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-793)


[GW-793]: https://technologyprogramme.atlassian.net/browse/GW-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ