### PR TITLE
Update organisations.yml

### DIFF
--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -1,153 +1,268 @@
 - ACAS
-- Administrative Justice and Tribunals Council
 - Allerdale Borough Council
 - Avon & Somerset Police
+- Avon and Wiltshire Mental Health Partnership NHS Trust
+- Barts Health NHS Trust
+- Basingstoke and Deane Borough Council
 - Bath and North East Somerset Council
-- Birmingham City Council
-- Border Force
+- Bedford Borough Council
+- Black Country Healthcare NHS Foundation Trust
+- Black Country ICB
+- Blackburn with Darwen Borough Council
+- Blackpool Borough Council
+- Blaenau Gwent County Borough Council
 - Borough Council of King's Lynn and West Norfolk
+- Bournemouth, Christchurch and Poole Council
 - Braintree District Council
+- Brentwood Borough Council
 - Brighton and Hove City Council
 - British Tourist Authority
-- British Transport Police Authority
+- British Transport Police
 - Cabinet Office
 - Cambridgeshire Constabulary
+- Cambridgeshire County Council
+- Cambridgeshire Fire & Rescue Service
 - Camden Council
 - Ceredigion County Council
+- Cherwell District Council
 - Chesterfield Royal Hospital NHS Trust
 - City of Lincoln Council
+- City of Westminster
+- City of Wolverhampton Council
+- City of York Council
 - Cleveland Police
 - Companies House
+- Competition and Markets Authority
 - County Durham and Darlington Fire and Rescue Service
-- Crown Commercial Service
+- Crown Prosecution Service
+- Dacorum Borough Council
+- Defence Equipment and Support
 - Department for Business, Energy & Industrial Strategy
+- Department for Digital, Culture, Media and Sport
 - Department for Education
 - Department for Environment, Food & Rural Affairs
 - Department for International Development
 - Department for Transport
 - Department for Work and Pensions
+- Department of Finance and Personnel for Northern Ireland
 - Department of Health and Social Care
 - Derby City Council
 - Derbyshire Constabulary
 - Derbyshire County Council
+- Derbyshire Fire & Rescue Service
 - Devon & Cornwall Police & Dorset Police
+- Devon and Somerset Fire and Rescue service
 - Devon County Council
-- Devon Integrated Children's Services
 - Devon Partnership NHS Trust
+- Doncaster Metropolitan Borough Council
+- Dorset and Wiltshire Fire and Rescue Service
 - Dorset Council
-- DPT The Cedars, Exeter
+- Dounreay Site Restoration Limited
+- Driver and Vehicle Licensing Agency
+- Driver and Vehicle Standards Agency
+- Dudley Group NHS Foundation Trust
 - Dudley Metropolitan Borough Council
 - Durham Constabulary
+- Durham County Council
 - East Devon District Council
+- East Suffolk & North Essex NHS Foundation Trust
 - East Sussex County Council
+- East Sussex Fire and Rescue Service
 - Eastbourne Borough Council
-- Environment Agency
-- Essex County Council
 - Essex County Fire and Rescue Service
 - Exeter City Council
+- Fenland District Council
+- Food Standards Agency
 - Foreign & Commonwealth Office
+- Forest Research
 - Gateshead Metropolitan Borough Council
+- Gloucester City Council
 - Gloucester Police
+- Gloucestershire County Council
 - Government Actuary's Department
-- Government Certified Training (GCT)
 - Government Digital Service
 - Government Legal Department
-- GovWifi Developers
-- GovWifi Super Administrators
+- Government Property Agency
 - GPA
 - GPA Hubs
+- Great Western Hospitals NHS Foundation Trust
+- Greater London Authority
+- Greater Manchester Combined Authority
+- Greater Manchester Mental Health NHS Foundation Trust
+- Guildford Borough Council
+- Gwent Police
+- Hampshire & Isle of Wight Fire and Rescue Service
+- Hampshire Constabulary
+- Hartlepool Borough Council
 - Health and Safety Executive
-- Healthcare UK
+- Health and Social Care Northern Ireland
+- Hereford & Worcester Fire and Rescue Service
+- Herefordshire and Worcestershire Clinical Commissioning Group
+- Herefordshire and Worcestershire Health and Care NHS Trust
+- Herefordshire Council
 - Hertfordshire Constabulary/Bedfordshire Police
+- High Speed Two (HS2) Limited
 - HM Courts & Tribunals Service
 - HM Land Registry
 - HM Revenue & Customs
 - Home Office
 - Homes England
-- Hull And East Yorkshire Hospitals NHS TRUST
+- Housing Ombudsman
+- Humber Teaching NHS Foundation Trust
 - Independent Police Complaints Commission
-- Innovate UK
 - Intellectual Property Office
-- Islington Council
 - Kent and Essex Police
-- Kent county council
 - Lancashire County Council
+- Lancaster City Council
+- Leicestershire Fire and Rescue Service
 - Lichfield District Council
+- Lisburn & Castlereagh City Council
 - London Borough of Brent
+- London Borough of Bromley
 - London Borough of Hackney
-- Manchester Central / WifiSpark - CYBERUK
+- London Borough of Lambeth
+- London Borough of Merton
+- London Borough of Newham
+- London Borough of Redbridge
+- London Borough of Tower Hamlets
+- London Borough of Waltham Forest
+- London Fire Brigade
+- Loughborough University
+- Magnox Ltd
 - Maritime and Coastguard Agency
 - Medical Research Council
 - Medicines and Healthcare products Regulatory Agency
 - Met Office
 - Metropolitan Police Service - Hendon
-- Metropolitan Police Service - TTP Programme
 - Ministry of Defence
 - Ministry of Housing, Communities and Local Government
 - Ministry of Justice
+- Monmouthshire County Council
 - NAO
-- National College of High Speed Rail
-- National Cyber Security Centre
+- National Probation Service
+- Natural Resources Wales
 - Newcastle City Council
 - NHS Arden and Greater East Midlands
+- NHS Cheshire and Merseyside
+- NHS Devon
 - NHS Digital
-- NHS England
-- NHS Professionals
+- NHS Greater Manchester Integrated Care
+- NHS Midlands & Lancashire Commissioning Support Unit (MLCSU)
+- NHS South, Central and West Commissioning Support Unit
+- NHS Swindon CCG
 - Norfolk & Suffolk Constabulary
 - Norfolk Fire and Rescue Service
-- North Tyneside Council
+- North Northamptonshire Unitary Council
+- North of England Commissioning Support (NECS)
+- North Sea Transition Authority
+- North Somerset  Council
 - North Yorkshire Police
 - Northern Devon Healthcare NHS Trust
 - Northern Ireland Civil Service
+- Northern Ireland Courts & Tribunals Service
 - Northumberland County Council
+- Nottingham and Nottinghamshire ICB
 - Nottingham City Council
+- Nottinghamshire County Council
+- Nottinghamshire Fire & Rescue Service
+- Nuclear Decommissioning Authority
+- Nuclear Waste Services
 - Nuneaton and Bedworth Borough Council
+- Ofcom
 - Office for National Statistics
+- Office for Nuclear Regulation
+- Office for Students
 - Office of Rail and Road
+- Office of the Secretary of State for Wales
 - Ofgem
 - Ofqual
-- Peterborough City Council
+- Oxfordshire County Council
+- Pennine Care NHS Foundation Trust
+- Pension Protection Fund
+- Plymouth City Council
 - Plymouth Hospitals NHS Trust
-- RCDTS
-- Redcar and Cleveland Borough Council
+- Police Service of Northern Ireland
+- Public Health England
 - Redditch Borough Council
+- Registers of Scotland
+- Rochdale Metropolitan Borough Council
+- Rochford District Council
 - Rother District Council
+- Royal Borough of Kensington and Chelsea
 - Royal Devon and Exeter NHS Foundation Trust
 - Royal Welsh College of Music & Drama
+- Royal Wolverhampton NHS Trust
 - Rugby Borough Council
+- Salford City Council
+- Salisbury NHS Foundation Trust
+- sandwell and west birmingham nhs trust
+- Sandwell Metropolitan Borough Council
 - Science and Technology Facilities Council
-- Scottish Environment Protection Agency (SEPA)
 - Scottish Event Campus
 - Scottish Government
 - Sellafield Ltd
-- Shared Resource Service (SRS) BGCBC (Blaenau Gwent County Borough Council)
-- Shared Resource Service (SRS) GPA (Gwent police)
-- Shared Resource Service (SRS) MCC
-- Shared Resource Service (SRS) TCBC
+- Serious Fraud Office
+- Shropshire Fire and Rescue Service
+- Single Source Regulations Office
 - Social Work England
 - Solihull Metropolitan Borough Council
 - Somerset County Council
+- South Downs National Park Authority
+- South Gloucestershire Council
 - South Hams District Council & West Devon Borough Council
+- South Somerset District Council
+- South Staffordshire Council
 - South Wales Police Headquarters
+- South Western Ambulance Service NHS Foundation Trust
 - Southampton City Council
+- Stockport Metropolitan Borough Council
 - Stockton-on-Tees Borough Council
+- Stoke-on-Trent City Council
 - Student Loans Company
+- Submarine Delivery Agency
+- Sunderland City Council
 - Surrey County Council
+- SUSSEX COMMUNITY NHS FOUNDATION TRUST
+- Swansea Council
 - Swindon Borough Council
+- Tameside and Glossop Integrated Care NHS Foundation Trust
+- Tameside Metropolitan Borough Council
 - Teignbridge District Council
+- Thales Group
+- Thames Valley Police
+- The Mayor's Office for Policing And Crime
 - The National Archives
-- Tonbridge and Malling Borough Council
+- The Parliamentary and Health Service Ombudsman
 - Torbay and South Devon NHS Foundation Trust
+- Torfaen County Borough Council
+- Transport for Greater Manchester
 - Transport for London (TfL)
-- Treasury (HMT)
 - Tyne & Wear NHS Trust
+- Tyne and Wear Fire and Rescue Service
+- UK Debt Management Office
+- UK Hydrographic Office
 - UK Research and Innovation
-- Unified Patent Court (UPC)
-- Upper Tribunal
+- UKSBS - Shared Business Service
+- University Hospitals of Derby and Burton NHS Foundation Trust
 - Valuation Office Agency
+- Velindre University NHS Trust
+- Wales Audit Office
+- Walsall Healthcare NHS Trust
 - Warwick District Council
 - Warwickshire County Council
-- Water Search and Rescue Team
+- Warwickshire Police
+- Wealden District Council
+- West Dunbartonshire Council
+- West Mercia Police
+- West Midlands Combined Authority
 - West Midlands Fire Service
+- West Northamptonshire Unitary Council
+- West Oxfordshire District Council
+- West Yorkshire Combined Authority
+- Wigan Metropolitan Borough Council
+- Wiltshire Council
+- Wiltshire Health & Care
+- Wiltshire Police
 - Worcestershire County Council
-- Wychavon District Council
+- Wrightington, Wigan and Leigh Teaching Hospitals NHS Foundation Trust
+- Wye Valley NHS Trust


### PR DESCRIPTION
Edit the public list of organisations using GovWifi

### What
Removed certain organisations and added others to the public list of organisations.

### Why
Multiple reasons - names have changed, some organisations no one exist, listing other organisations who aren't running GovWifi but another organisation does it on their behalf. The list was very out of date so it needed a big update. In the future it should be getting them on a more ad hoc basis.


Link to Jira card (if applicable):  https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5bcd8dd81582cc3b70155430&selectedIssue=GW-888
