### PR TITLE
Changed link for Service Performance

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -67,7 +67,7 @@
                 <%= link_to 'Terms and conditions', '/terms-and-conditions', class: 'govuk-footer__link' %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Service performance', 'https://www.gov.uk/performance/govwifi', class: 'govuk-footer__link' %>
+                <%= link_to 'Service performance', 'https://www.data.gov.uk/search?q=GovWifi', class: 'govuk-footer__link' %>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
### What
Changed the link used for Service Performance in footer -
from: https://www.gov.uk/performance/govwifi
to: https://www.data.gov.uk/search?q=GovWifi

### Why
Link was out of date


Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-181