### PR TITLE
fix: [GW-1062] Add redirect for old link

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -54,3 +54,5 @@ helpers do
     'govuk-header__navigation-item--active' if current_page.url.start_with? (root_scope or url)
   end
 end
+
+redirect "about-govwifi/connect-to-govwifi.html", to: "/connect-to-govwifi/"


### PR DESCRIPTION
### What
add a redirect for an old link that still seems to exist on posters 

### Why
Users are getting a 404 and not being redirected to the new location.


Link to Trello card (if applicable): 
GW-1062

If applied we should do 'out of hours' as this might show the readme page upon first deployment.