### PR TITLE
fix: [GW-1254] prevent github showing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ rspec ./spec/features/
 ```
 
 ## Deploying
-This is deployed to github pages, via a workflow.  Has been noticed that on occasions it can 'stick' on the ```setup node``` step, if this happens, terminate the job and rerun.  Also it something just deploys this readme instead of the main content, to fix this just the workflow again.
+This is deployed to github pages, via a workflow.  Has been noticed that on occasions it can 'stick' on the ```setup node``` step, if this happens, terminate the job and rerun.
 
 ## Contributing
 


### PR DESCRIPTION
### What
Add a file to tell github not to display the readme page, reference https://github.com/orgs/community/discussions/22400#discussioncomment-7404883

### Why
Upon first deployment, Git Hub Pages deploys the README.md file instead of the MiddleMan content.


Link to Trello card (if applicable): 
[GW-1254](https://technologyprogramme.atlassian.net/browse/GW-1254)

[GW-1254]: https://technologyprogramme.atlassian.net/browse/GW-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ