### PR TITLE
create MOU page for the product page

### DIFF
--- a/source/memorandum-of-understanding.html.erb
+++ b/source/memorandum-of-understanding.html.erb
@@ -8,7 +8,7 @@ description: These terms apply to your use of GovWifi. You must agree to these t
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">GovWifi Memorandum of Understanding</h1>
         <p class="govuk-body">For use by both Crown and non-Crown bodies</p>
-        <p class="govuk-body">This Agreement is made on the date listed above, between: The Cabinet Office Digital, a division of The Cabinet Office, based at Government Offices Great George Street, 1 Horse Guards Road, London, SW1A 2HQ and an organisation which offers GovWifi, hereafter referred to as ‘the Organisation’.</p>
+        <p class="govuk-body">This Agreement is made on the date listed above, between: Cabinet Office Digital, a division of The Cabinet Office, based at Government Offices Great George Street, 1 Horse Guards Road, London, SW1A 2HQ and an organisation which offers GovWifi, hereafter referred to as ‘the Organisation’.</p>
         <h2 class="govuk-heading-m">Introduction</h2>
         <p class="govuk-body">This document sets out the agreement between GovWifi, part of the Cabinet Office, and the Organisation in relation to the use of GovWifi, with particular emphasis on data protection and escalation routes.</p>
         <h2 class="govuk-heading-m">Purpose of GovWifi</h2>
@@ -445,7 +445,7 @@ description: These terms apply to your use of GovWifi. You must agree to these t
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">2.3</td>
               <td class="govuk-table__cell">13.02.24</td>
-              <td class="govuk-table__cell">Removed content related to signing as MOU will be moved to an online version. Updated the GovWifi office address. Replaced references from “CDIO” with “Cabinet Office”. Removed concept of a “primary point of contact” from section 3.2. Updated GovWifi Product Managers’ name from Rory Langford to Fajer Qasem. Other updates to sections 5.2a, 16.1 and 16.2</td>
+              <td class="govuk-table__cell">Removed content related to signing as MOU will be moved to an online version. Updated the GovWifi office address. Replaced references from “CDIO” with “Cabinet Office”. Removed concept of a “primary point of contact” from section 3.2. Updated GovWifi contacts for Product Manager, Head of Product and SRO. Other updates to sections 5.2a, 16.1 and 16.2</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
### What
We are moving the MOU from the tech docs to the product page

### Why
We use the product page for similar pages and it makes more sense to put the MOU page here


Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1433