### PR TITLE
create some shortened urls and redirects for notify

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -56,3 +56,7 @@ helpers do
 end
 
 redirect "about-govwifi/connect-to-govwifi.html", to: "/connect-to-govwifi/"
+
+redirect "help.html", to: "/get-help-connecting/"
+redirect "privacy.html", to: "/privacy-notice/"
+redirect "terms.html", to: "/terms-and-conditions/"


### PR DESCRIPTION
### What

We have really long URLs. Not bad in itself but it is really bulky when looking at text messages. It takes up lots of the message for users but also means our SMS costs are higher. 

### Why

We can save around £15k a year by cutting the sign up message down from 4 messages to 3.

It’ll be easier for users to parse the message rather than reading long URLs

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-1417