### PR TITLE
Revert "build(deps): bump govuk-frontend from 4.7.0 to 5.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "gaap-analytics": "^3.1.0",
-        "govuk-frontend": "^5.3.1",
+        "govuk-frontend": "^4.7.0",
         "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
       }
     },
@@ -21,9 +21,9 @@
       "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.1.tgz",
-      "integrity": "sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -57,9 +57,9 @@
       "integrity": "sha512-9G7Hwy/D2bjFymOQIptNArrTDAgGjssAv+L6SvbAJinDOSzeX9zUc46PnDVA5WPHHUC5+er4y9+o/nYbubwPoA=="
     },
     "govuk-frontend": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.1.tgz",
-      "integrity": "sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "govwifi-shared-frontend": {
       "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/alphagov/govwifi-product-page#readme",
   "dependencies": {
     "gaap-analytics": "^3.1.0",
-    "govuk-frontend": "^5.3.1",
+    "govuk-frontend": "^4.7.0",
     "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
   },
   "scripts": {


### PR DESCRIPTION
Reverts alphagov/govwifi-product-page#493

This is a breaking change reverting: https://github.com/alphagov/govwifi-product-page/actions/runs/9018780607/job/24780144249#step:4:9