### PR TITLE
Updating list of organisations using GovWifi

### DIFF
--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -11,41 +11,55 @@
 - Blackburn with Darwen Borough Council
 - Blackpool Borough Council
 - Blaenau Gwent County Borough Council
+- Bolton Metropolitan Borough Council
+- Bolton NHS Foundation Trust
 - Borough Council of King's Lynn and West Norfolk
 - Bournemouth, Christchurch and Poole Council
+- Bracknell Forest Council
 - Braintree District Council
 - Brentwood Borough Council
 - Brighton and Hove City Council
+- Bridgewater Community Healthcare NHS Foundation Trust
 - British Tourist Authority
 - British Transport Police
+- Burnley Borough Council
 - Cabinet Office
 - Cambridgeshire Constabulary
 - Cambridgeshire County Council
 - Cambridgeshire Fire & Rescue Service
 - Camden Council
+- Care Inspectorate
+- Care Quality Commission
+- Carterton Community College
 - Ceredigion County Council
 - Cherwell District Council
 - Chesterfield Royal Hospital NHS Trust
+- Cheltenham Borough Council
 - City of Lincoln Council
 - City of Westminster
 - City of Wolverhampton Council
 - City of York Council
 - Cleveland Police
+- College of Policing
 - Companies House
 - Competition and Markets Authority
 - County Durham and Darlington Fire and Rescue Service
+- Coventry City Council
 - Crown Prosecution Service
 - Dacorum Borough Council
 - Defence Equipment and Support
+- Defence Science and Technology Laboratory
 - Department for Business, Energy & Industrial Strategy
 - Department for Digital, Culture, Media and Sport
 - Department for Education
 - Department for Environment, Food & Rural Affairs
 - Department for International Development
+- Department for International Trade
 - Department for Transport
 - Department for Work and Pensions
 - Department of Finance and Personnel for Northern Ireland
 - Department of Health and Social Care
+- Department of Health, Social Services and Public Safety
 - Derby City Council
 - Derbyshire Constabulary
 - Derbyshire County Council
@@ -64,16 +78,21 @@
 - Dudley Metropolitan Borough Council
 - Durham Constabulary
 - Durham County Council
+- East Ayrshire Council
 - East Devon District Council
 - East Suffolk & North Essex NHS Foundation Trust
+- East Suffolk Council
 - East Sussex County Council
 - East Sussex Fire and Rescue Service
 - Eastbourne Borough Council
+- Edinburgh International Conference Centre
+- Epping Forest District Council
 - Essex County Fire and Rescue Service
 - Exeter City Council
 - Fenland District Council
 - Food Standards Agency
 - Foreign & Commonwealth Office
+- Foreign, Commonwealth & Development Office
 - Forest Research
 - Gateshead Metropolitan Borough Council
 - Gloucester City Council
@@ -103,23 +122,35 @@
 - Hertfordshire Constabulary/Bedfordshire Police
 - High Speed Two (HS2) Limited
 - HM Courts & Tribunals Service
+- HM Inspectorate of Constabulary and Fire & Rescue Services
 - HM Land Registry
 - HM Revenue & Customs
 - Home Office
 - Homes England
 - Housing Ombudsman
 - Humber Teaching NHS Foundation Trust
+- Human Fertilisation and Embryology Authority
+- Independent Office for Police Conduct
 - Independent Police Complaints Commission
 - Intellectual Property Office
+- Judicial Office
 - Kent and Essex Police
 - Lancashire County Council
 - Lancaster City Council
+- Leeds City Council
+- Leicestershire County Council
 - Leicestershire Fire and Rescue Service
 - Lichfield District Council
+- Lincolnshire Community Health Services NHS Trust
+- Lincolnshire ICB
+- Lincolnshire Partnership NHS Foundation Trust
 - Lisburn & Castlereagh City Council
+- LLW Repository Ltd
+- London Borough of Bexley
 - London Borough of Brent
 - London Borough of Bromley
 - London Borough of Hackney
+- London Borough of Harrow
 - London Borough of Lambeth
 - London Borough of Merton
 - London Borough of Newham
@@ -129,38 +160,51 @@
 - London Fire Brigade
 - Loughborough University
 - Magnox Ltd
+- Manchester City Council
+- Manufacturing Technology Centre
 - Maritime and Coastguard Agency
 - Medical Research Council
 - Medicines and Healthcare products Regulatory Agency
+- Mersey West Lancs Teaching Hospitals
 - Met Office
 - Metropolitan Police Service - Hendon
+- Mid Devon District Council
 - Ministry of Defence
 - Ministry of Housing, Communities and Local Government
 - Ministry of Justice
 - Monmouthshire County Council
 - NAO
+- National Institute for Health and Care Excellence
 - National Probation Service
 - Natural Resources Wales
+- NatureScot
+- Neath Port Talbot Council
 - Newcastle City Council
 - NHS Arden and Greater East Midlands
 - NHS Cheshire and Merseyside
 - NHS Devon
 - NHS Digital
+- NHS England
 - NHS Greater Manchester Integrated Care
+- NHS Hampshire and Isle of Wight ICB
+- NHS Lincolnshire ICS GP Practices
 - NHS Midlands & Lancashire Commissioning Support Unit (MLCSU)
 - NHS South, Central and West Commissioning Support Unit
 - NHS Swindon CCG
 - Norfolk & Suffolk Constabulary
 - Norfolk Fire and Rescue Service
+- North Ayrshire Council
 - North Northamptonshire Unitary Council
 - North of England Commissioning Support (NECS)
 - North Sea Transition Authority
 - North Somerset  Council
+- North Tyneside Council
 - North Yorkshire Police
 - Northern Devon Healthcare NHS Trust
 - Northern Ireland Civil Service
 - Northern Ireland Courts & Tribunals Service
 - Northumberland County Council
+- Northumberland National Park Authority
 - Nottingham and Nottinghamshire ICB
 - Nottingham City Council
 - Nottinghamshire County Council
@@ -174,6 +218,7 @@
 - Office for Students
 - Office of Rail and Road
 - Office of the Secretary of State for Wales
+- Oldham Metropolitan Borough Council
 - Ofgem
 - Ofqual
 - Oxfordshire County Council
@@ -182,20 +227,28 @@
 - Plymouth City Council
 - Plymouth Hospitals NHS Trust
 - Police Service of Northern Ireland
+- Portsmouth City Council
+- Professional Standards Authority for Health and Social Care
 - Public Health England
 - Redditch Borough Council
 - Registers of Scotland
+- Regulator of Social Housing
 - Rochdale Metropolitan Borough Council
 - Rochford District Council
 - Rother District Council
+- Royal Air Force Air Cadets
+- Royal Air Force Air Cyberspace Services Centre
+- Royal Air Force Rapid Capabilities Office AIX
 - Royal Borough of Kensington and Chelsea
+- Royal Borough of Kingston upon Thames
 - Royal Devon and Exeter NHS Foundation Trust
+- Royal United Hospitals NHS Foundation Trust
 - Royal Welsh College of Music & Drama
 - Royal Wolverhampton NHS Trust
 - Rugby Borough Council
 - Salford City Council
 - Salisbury NHS Foundation Trust
-- sandwell and west birmingham nhs trust
+- Sandwell and West Birmingham NHS trust
 - Sandwell Metropolitan Borough Council
 - Science and Technology Facilities Council
 - Scottish Event Campus
@@ -214,13 +267,19 @@
 - South Staffordshire Council
 - South Wales Police Headquarters
 - South Western Ambulance Service NHS Foundation Trust
+- South West London and St George's Mental Health NHS Trust
 - Southampton City Council
+- St Albans City and District Council
+- Staffordshire County Council
 - Stockport Metropolitan Borough Council
+- Stockport NHS Foundation Trust
 - Stockton-on-Tees Borough Council
 - Stoke-on-Trent City Council
+- Strata Service Solutions Ltd
 - Student Loans Company
 - Submarine Delivery Agency
 - Sunderland City Council
+- Surrey and Sussex Police
 - Surrey County Council
 - SUSSEX COMMUNITY NHS FOUNDATION TRUST
 - Swansea Council
@@ -230,8 +289,11 @@
 - Teignbridge District Council
 - Thales Group
 - Thames Valley Police
+- The Children and Family Court Advisory and Support Service
+- The Insolvency Service
 - The Mayor's Office for Policing And Crime
 - The National Archives
+- The Office for Environmental Protection
 - The Parliamentary and Health Service Ombudsman
 - Torbay and South Devon NHS Foundation Trust
 - Torfaen County Borough Council
@@ -242,12 +304,16 @@
 - UK Debt Management Office
 - UK Hydrographic Office
 - UK Research and Innovation
+- UK Space Agency
 - UKSBS - Shared Business Service
+- Undercover Policing Inquiry
+- United Lincolnshire Hospitals NHS Trust
 - University Hospitals of Derby and Burton NHS Foundation Trust
 - Valuation Office Agency
 - Velindre University NHS Trust
 - Wales Audit Office
 - Walsall Healthcare NHS Trust
+- Walsall Metropolitan Borough Council
 - Warwick District Council
 - Warwickshire County Council
 - Warwickshire Police
@@ -265,4 +331,5 @@
 - Wiltshire Police
 - Worcestershire County Council
 - Wrightington, Wigan and Leigh Teaching Hospitals NHS Foundation Trust
+- Wychavon District Council
 - Wye Valley NHS Trust


### PR DESCRIPTION
### What
Update the Org list

### Why
To accurately show who is using GovWifi

So end users know where they can expect GovWifi to be visible


Link to Trello card (if applicable) : GW-1802 https://technologyprogramme.atlassian.net/browse/GW-1802
