### PR TITLE
Fix Navigation On Sidebar

### DIFF
--- a/source/privacy-notice.html.erb
+++ b/source/privacy-notice.html.erb
@@ -29,7 +29,7 @@ description: GovWifi privacy notice - how we collect and process your data.
           <%= link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053", class: "govuk-link" %> for more information.
         </p>
         <h2 class="govuk-heading-m" id="what-data-we-need">Your data</h2>
-        <p class="govuk-body">
+        <p class="govuk-body" id="what-data-we-need">
         To ensure GovWifi works effectively we collect the following data:
         </p>
         <ul class="govuk-list govuk-list--bullet">
@@ -69,7 +69,7 @@ description: GovWifi privacy notice - how we collect and process your data.
 
         <h2 class="govuk-heading-m" id="legal-basis">Legal basis for processing your data</h2>
 
-        <p class="govuk-body">
+        <p class="govuk-body" id="legal-basis" >
           The legal basis for processing your personal data is:
         </p>
     
@@ -77,13 +77,13 @@ description: GovWifi privacy notice - how we collect and process your data.
 Processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the data controller. In this case that is the running of wifi services.
           </p>
   <h2 class="govuk-heading-m" id="user-research">For user research</h2>
-     <p class="govuk-body">The initial use of personal data to send surveys (when data subjects sign up for GovWifi credentials) is on a lawful basis of legitimate interest.</p>
+     <p class="govuk-body" id="why-we-need-it">The initial use of personal data to send surveys (when data subjects sign up for GovWifi credentials) is on a lawful basis of legitimate interest.</p>
 
 <p class="govuk-body">All other processing for user research is on a lawful basis of consent.</p>
 
    <h2 class="govuk-heading-m" id="recipients">Recipients</h2>
  
-<p class="govuk-body">Your personal data may be shared with other government departments in specific circumstances such as investigations: </p>
+<p class="govuk-body" id="what-we-do-with-it">Your personal data may be shared with other government departments in specific circumstances such as investigations: </p>
  <ul class="govuk-list govuk-list--bullet">
           <li>legal investigations</li>
   <li>cyber Security investigations</li>
@@ -102,7 +102,7 @@ Processing is necessary for the performance of a task carried out in the public 
  
 <h2 class="govuk-heading-m" id="data-retention">Data retention</h2>
 
-<p class="govuk-body">We need to process personal data to let users in government, arm’s length bodies and public sector organisations stay connected to a secure wifi service while visiting other departments and moving between buildings.</p>
+<p class="govuk-body" id="how-long-we-keep-your-data">We need to process personal data to let users in government, arm’s length bodies and public sector organisations stay connected to a secure wifi service while visiting other departments and moving between buildings.</p>
 <p class="govuk-body">We need to know when you last used GovWifi so we can delete your account if it has not been used for 12 months.</p>
 <p class="govuk-body">We need to know your email address or mobile phone number so that we can notify you about major changes to the service or changes to the terms and conditions. For example, if the current inactive account deletion period of 12 months is reduced.</p>
 <p class="govuk-body">We will keep connection log data for a maximum of 6 months.</p>
@@ -116,7 +116,7 @@ Processing is necessary for the performance of a task carried out in the public 
  
 
 <h2 class="govuk-heading-m" id="your-rights">Your rights</h2>
- <p class="govuk-body">You have the right:</p>
+ <p class="govuk-body" id="what-are-your-rights">You have the right:</p>
 <ul class="govuk-list govuk-list--bullet">
           <li>to request information about how your personal data is processed, and to request a copy of that personal data</li>
  
@@ -194,7 +194,7 @@ Wycliffe House
           SW1A 2AS
         </p>
 
- <p class="govuk-body">
+ <p class="govuk-body" id="how-to-contact-us">
           Alternatively you can use this online form to <%= link_to "contact Cabinet Office", "https://www.gov.uk/guidance/contact-the-cabinet-office", class: "govuk-link" %>
         </p>
 

--- a/source/shared/_privacy_notice_sidebar.html.erb
+++ b/source/shared/_privacy_notice_sidebar.html.erb
@@ -5,11 +5,7 @@
   { title: "Why we need your data", link: "#why-we-need-it" },
   { title: "What we do with your data", link: "#what-we-do-with-it" },
   { title: "How long we keep your data", link: "#how-long-we-keep-your-data" },
-  { title: "Children’s privacy protection", link: "#childrens-privacy-protection" },
-  { title: "Where your data is processed and stored", link: "#where-it-might-go" },
-  { title: "How we protect your data and keep it secure", link: "#how-we-protect-your-data-and-keep-it-secure" },
   { title: "Your rights", link: "#what-are-your-rights" },
-  { title: "Changes to this notice", link: "#changes-to-this-notice" },
   { title: "How to contact us", link: "#how-to-contact-us" }
 ] %>
 


### PR DESCRIPTION
### What
Fix Navigation On Sidebar

### Why
Privacy page navigation was not functioning. Now fixed. Anchor tags were on wrong element. Corrected also removed navigation items that did not correlate to any actual content on the page.

