### PR TITLE
remove text related to using the same credentials across all devices

### DIFF
--- a/source/ask-staff-member.html.erb
+++ b/source/ask-staff-member.html.erb
@@ -32,7 +32,6 @@ description: GovWifi access for non-public sector staff
         <p class="govuk-body"> To connect your device, follow the guide for
           <%= partial 'shared/product/_links' %>
         </p>
-        <p class="govuk-body">You can use the same username and password to connect all your devices to GovWifi.</p>
       </main>
     </div>
   </div>

--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -27,7 +27,6 @@ description: How to connect devices to GovWifi.
         <p class="govuk-body"> To connect your device, follow the guide for
           <%= partial 'shared/product/_links' %>
         </p>
-        <p class="govuk-body">You can use the same username and password to connect all your devices to GovWifi.</p>
         <div class="govuk-inset-text">
           If you manage IT services in a public sector organisation and want to provide GovWifi in your buildings, see how to <%= link_to "offer GovWifi", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.
         </div>


### PR DESCRIPTION
### What

Remove text “You can use the same username and password to connect all your devices to GovWifi”  [Connect to GovWifi - GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/)

### Why

Required after Zendesk support ticket

### Link to JIRA card (if applicable):
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/browse/GW-2202)
