### PR TITLE
update text to emphasise that users should only use credentials for their own devices

### DIFF
--- a/source/ask-staff-member.html.erb
+++ b/source/ask-staff-member.html.erb
@@ -32,7 +32,7 @@ description: GovWifi access for non-public sector staff
         <p class="govuk-body"> To connect your device, follow the guide for
           <%= partial 'shared/product/_links' %>
         </p>
-        <p class="govuk-body">You can use the same username and password to connect all your devices to GovWifi.</p>
+        <p class="govuk-body">You can use the same username and password to connect only your personal devices to GovWifi.</p>
       </main>
     </div>
   </div>

--- a/source/connect-to-govwifi.html.erb
+++ b/source/connect-to-govwifi.html.erb
@@ -27,7 +27,7 @@ description: How to connect devices to GovWifi.
         <p class="govuk-body"> To connect your device, follow the guide for
           <%= partial 'shared/product/_links' %>
         </p>
-        <p class="govuk-body">You can use the same username and password to connect all your devices to GovWifi.</p>
+        <p class="govuk-body">You can use the same username and password to connect only your personal devices to GovWifi.</p>
         <div class="govuk-inset-text">
           If you manage IT services in a public sector organisation and want to provide GovWifi in your buildings, see how to <%= link_to "offer GovWifi", "https://docs.wifi.service.gov.uk/", class: "govuk-link" %>.
         </div>


### PR DESCRIPTION
### What
Update text to emphasise that users should only use credentials for their own devices and not to share credentials with users for other devices

From : “You can use the same username and password to connect all your devices to GovWifi”  

TO: You can use the same username and password to connect only your personal devices to GovWifi” 

### Why
Users have been using their credentials for devices that are not their own; this creates a problem for network admins who need to identify owners of devices, in case of issues such as malware.

### Link to JIRA card (if applicable):
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/browse/GW-2202)
