### PR TITLE
Update the instructions to connect to Android

### DIFF
--- a/source/device-android.html.erb
+++ b/source/device-android.html.erb
@@ -32,6 +32,12 @@ description: Follow these instructions to connect your Android device to GovWifi
             <p class="govuk-body">For <strong>CA Certificate</strong>, select <strong>Use system certificates</strong> - if this option is not shown select <strong>Do not validate</strong>.</p>
           </li>
           <li>
+            <p class="govuk-body">If the option <strong>Minimum TLS version</strong> is shown, select <strong>TLS v1.2</strong></p>
+          </li>
+          <li>
+            <p class="govuk-body">If the option <strong>Online Certificate Status</strong> is shown, select <strong>Do Not Verify</strong>.</p>
+          </li>
+          <li>
             <p class="govuk-body">For <strong>Domain</strong>, enter wifi.service.gov.uk</p>
           </li>
           <li>


### PR DESCRIPTION
Later versions of Android have two extra options:

'Minimum TLS version'. This should be set to v1.2 because others are insecure 'Online Certificate Status', which uses OCSP to check if our certificate is revoked. As we don't use  that I recommend setting this to 'Do not verify'.

Both option can be shown or not, depending on the version of Android used

https://technologyprogramme.atlassian.net/browse/GW-2346