### PR TITLE
Automate pulling organisations from admin

### DIFF
--- a/.github/workflows/fetch-orgs.yml
+++ b/.github/workflows/fetch-orgs.yml
@@ -1,0 +1,56 @@
+name: Fetch an updated list of organisations that use GovWifi from GovWifi-Admin
+
+on:
+  schedule:
+    - cron: "0 10 1 * *" # Runs monthly on day 1 at 10:00 UTC (opens a PR if data changed
+  workflow_dispatch: # Run manually from Actions (opens a PR if data changed, never pushes to master)
+
+permissions: {}
+
+jobs:
+  fetch-orgs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        with:
+          bundler-cache: true
+
+      - name: Run fetch_orgs rake task
+        run: bundle exec rake data:fetch_orgs
+
+      - name: Detect data changes
+        id: changes
+        run: |
+          if git diff --quiet --exit-code -- data/organisations.yml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No organisation changes
+        if: steps.changes.outputs.changed == 'false'
+        run: echo "No updates found in data/organisations.yml"
+
+      - name: Create or update pull request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          commit-message: "Update organisations data"
+          branch: chore/update-organisations-data
+          base: master
+          title: "Update organisations data"
+          body: |
+            ## What changed
+            - Ran `bundle exec rake data:fetch_orgs`
+            - Updated `data/organisations.yml` with latest organisation list

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -40,6 +40,7 @@
 - Cambridgeshire County Council
 - Cambridgeshire Fire & Rescue Service
 - Camden Council
+- Cannock Chase District Council
 - Care Inspectorate
 - Care Quality Commission
 - Carterton Community College
@@ -109,6 +110,7 @@
 - Eastbourne Borough Council
 - Eastleigh Borough Council
 - Edinburgh International Conference Centre
+- Elmbridge Borough Council
 - Environment Agency
 - Epping Forest District Council
 - Erewash Borough Council
@@ -152,6 +154,7 @@
 - Herefordshire and Worcestershire Health and Care NHS Trust
 - Herefordshire Council
 - Hertfordshire Constabulary/Bedfordshire Police
+- Hertfordshire County Council
 - High Speed Two (HS2) Limited
 - HM Courts & Tribunals Service
 - HM Inspectorate of Constabulary and Fire & Rescue Services
@@ -218,6 +221,7 @@
 - mod
 - MoD LEARN
 - MoD-PJHQ
+- Mole Valley District Council
 - NAO
 - National Institute for Health and Care Excellence
 - National Oceanography Centre
@@ -341,6 +345,7 @@
 - St Albans City and District Council
 - Staffordshire County Council
 - Staffordshire Police
+- Stevenage Borough Council
 - Stockport Metropolitan Borough Council
 - Stockport NHS Foundation Trust
 - Stockton-on-Tees Borough Council
@@ -386,6 +391,7 @@
 - University Hospitals of Derby and Burton NHS Foundation Trust
 - University of Nottingham
 - Velindre University NHS Trust
+- Wakefield Metropolitan District Council
 - Wales Audit Office
 - Walsall Healthcare NHS Trust
 - Walsall Metropolitan Borough Council
@@ -409,6 +415,7 @@
 - Wiltshire Police
 - Winchester City Council
 - Wirral Borough Council
+- Wirral Community Health & Care NHS Trust
 - Wirral University Teaching Hospital NHS Foundation Trust
 - Wokingham Borough Council
 - Worcestershire Acute Hospitals NHS Trust


### PR DESCRIPTION
### What
Automate the rake task on the product page to update the organisations list on the admin portal using Github actions. 

How it starts
**Manually:** Actions → that workflow → Run workflow (workflow_dispatch).
**Automatically:** once a month (1st at 10:00 UTC) via the cron schedule.

What it does when it runs
Checks out the repo.
Runs bundle exec rake data:fetch_orgs (pulls the list from S3 and updates data/organisations.yml).
Checks whether that file changed.
If nothing changed → job finishes with “No updates found”.

### Why
We have a list of organisations in three places and when one is updated it is not automatically updated elsewhere. 
Reduce the number of Zendesk requests we get regarding the list being outdated on the product page.

Have an updated list all platforms 
### Link to JIRA card (if applicable):
[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)
https://technologyprogramme.atlassian.net/browse/GW-2744
