### PR TITLE
GW-2666 update certs 2026

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,12 +44,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     }
   }

--- a/source/update-govwifi-server-certificate.html.erb
+++ b/source/update-govwifi-server-certificate.html.erb
@@ -25,7 +25,8 @@ description: Information about accepting the new GovWifi server certificate to k
           <li>View the certificate.</li>
           <li>Check that the domain is <strong>wifi.service.gov.uk</strong></li>
           <li>Check the issuer is <strong>GeoTrust TLS RSA CA G1</strong></li>
-          <li>Check the fingerprint or thumbprint is <strong>1F A7 92 7B 11 04 A4 C5 A6 41 AC 25 32 34 E4 BD BF B3 E0 ED</strong></li>
+          <li>Check the fingerprint or thumbprint is <strong>1B BD C4 DA 2E 0A 08 C5 24 95 08 32 7C C9 24 C7 A1 5A 22 02</strong></li>
+          <li>You can check this by selecting 'more information' when presented with the certificate dialogue (Windows 11 or KeyChain on Mac)</li>
           <li>Accept or trust the new certificate.</li>
         </ol>
 

--- a/source/update-govwifi-server-certificate.html.erb
+++ b/source/update-govwifi-server-certificate.html.erb
@@ -26,7 +26,7 @@ description: Information about accepting the new GovWifi server certificate to k
           <li>Check that the domain is <strong>wifi.service.gov.uk</strong></li>
           <li>Check the issuer is <strong>GeoTrust TLS RSA CA G1</strong></li>
           <li>Check the fingerprint or thumbprint is <strong>1B BD C4 DA 2E 0A 08 C5 24 95 08 32 7C C9 24 C7 A1 5A 22 02</strong></li>
-          <li>You can check this by selecting 'more information' when presented with the certificate dialogue (Windows 11 or KeyChain on Mac)</li>
+          <li>You can check this by selecting 'more information' when presented with the certificate dialogue (Windows 11 or Keychain on Mac)</li>
           <li>Accept or trust the new certificate.</li>
         </ol>
 


### PR DESCRIPTION
### What
Update for new certificate

### Why
because we changed it

### Link to JIRA card (if applicable):
[GW-2666](https://technologyprogramme.atlassian.net/browse/GW-2666)
