### PR TITLE
Add workflow_dispatch trigger to GitHub Pages deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
     time: "03:00"
   open-pull-requests-limit: 10
   ignore:
-  # Disable ruby updates as this is hanled by git hub action.
+  # Disable ruby updates as this is handled  by github action.
   - dependency-name: "ruby"
 - package-ecosystem: npm
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+  ignore:
+  # Disable ruby updates as this is hanled by git hub action.
+  - dependency-name: "ruby"
 - package-ecosystem: npm
   directory: "/"
   schedule:

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
### What
Add manual deploy

### Why
So when Actions fail, we can manually deploy

### Link to JIRA card (if applicable):
n/a
