### PR TITLE
Updated the dependency of govwifi-shared-frontend to the latest tagged release.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "gaap-analytics": "^3.1.0",
         "govuk-frontend": "^5.11.12",
-        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.14/govwifi-shared-frontend-0.6.14.tgz"
+        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz"
       }
     },
     "node_modules/gaap-analytics": {
@@ -31,12 +31,12 @@
       }
     },
     "node_modules/govwifi-shared-frontend": {
-      "version": "0.6.14",
-      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.14/govwifi-shared-frontend-0.6.14.tgz",
-      "integrity": "sha512-oRJUrID9ZHYoHVQemEtbSbBihm3TwIr+T7b6e8MyLUc6yBczN1h4EeXuymKn1SilHq3yi2WynINtERM4w8b+Aw==",
+      "version": "0.6.21",
+      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz",
+      "integrity": "sha512-EDpJt9Hs9YC1Ee52uPrQlPI8/pzUSh/mXVfBAjnT03ariWyrBL9cS4iOr3KM/8hSutLgScikKW0KKFtqOIAq5w==",
       "license": "MIT",
       "dependencies": {
-        "js-cookie": "^3.0.5"
+        "js-cookie": "^3.0.7"
       },
       "engines": {
         "node": ">=18.17.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^5.11.12",
-    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.14/govwifi-shared-frontend-0.6.14.tgz"
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What
Updated the dependency of govwifi-shared-frontend to the latest tagged release.

### Why
Because dependabot flagged the dependent library as being vulnerable.
This app uses that library and therefore needs to use the patched (tagged) version.

### Link to JIRA card (if applicable):
[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)
