### PR TITLE
Add Cornwall Council and Spelthorne Borough Council, SBC

### DIFF
--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -59,12 +59,13 @@
 - College of Policing
 - Companies House
 - Competition and Markets Authority
+- Cornwall Council
 - Cornwall IT Services
 - Counter Terrorism Policing Headquarters
 - Countess Of Chester Hospital NHS Foundation Trust
 - County Durham and Darlington Fire and Rescue Service
 - Coventry City Council
-- Crown Office and Procurator Fiscal Service 
+- Crown Office and Procurator Fiscal Service
 - Crown Prosecution Service
 - Cumbria Constabulary
 - Dacorum Borough Council
@@ -342,6 +343,7 @@
 - South West London and St George's Mental Health NHS Trust
 - South Western Ambulance Service NHS Foundation Trust
 - Southampton City Council
+- Spelthorne Borough Council, SBC
 - St Albans City and District Council
 - Staffordshire County Council
 - Staffordshire Police

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -343,7 +343,7 @@
 - South West London and St George's Mental Health NHS Trust
 - South Western Ambulance Service NHS Foundation Trust
 - Southampton City Council
-- Spelthorne Borough Council, SBC
+- Spelthorne Borough Council
 - St Albans City and District Council
 - Staffordshire County Council
 - Staffordshire Police


### PR DESCRIPTION
## Add Cornwall Council and Spelthorne Borough Council, SBC

### What

- Add to the public organisation
    - Cornwall Council 
    - Spelthorne Borough Council, SBC

### Why

- We were asked to add these

### Link to JIRA card (if applicable):

- [GW-https://technologyprogramme.atlassian.net/browse/GW-2851](https://technologyprogramme.atlassian.net/browse/jira_id)
- [GW-https://technologyprogramme.atlassian.net/browse/GW-2852](https://technologyprogramme.atlassian.net/browse/jira_id)
